### PR TITLE
doc/toolchain_setup: Add missing apt dependency

### DIFF
--- a/doc/toolchain_setup.md
+++ b/doc/toolchain_setup.md
@@ -15,7 +15,7 @@ These steps are used to build and install the
                          python3-dev libboost-dev libeigen3-dev \
                          libboost-dev libboost-filesystem-dev \
                          libboost-thread-dev libboost-program-options-dev \
-                         libboost-iostreams-dev cmake
+                         libboost-iostreams-dev cmake libhidapi-dev
 
     git clone https://github.com/YosysHQ/icestorm
     cd icestorm


### PR DESCRIPTION
libhidapi-dev is required to build icestorm:
```
pi_pico_interface.c:5:10: fatal error: hidapi/hidapi.h: No such file
or directory
```

Tested with podman.

Signed-off-by: Marcello Sylvester Bauer <sylv@sylv.io>