### PR TITLE
Fix typo

### DIFF
--- a/hw/application_fpga/fw/mta1_mkdf/proto.h
+++ b/hw/application_fpga/fw/mta1_mkdf/proto.h
@@ -35,7 +35,7 @@ enum fwcmd {
 	FW_CMD_RUN_APP		= 0x07,
 	FW_RSP_RUN_APP		= 0x08,
 	FW_CMD_GET_APP_DIGEST	= 0x09,
-	FW_RSP_GET_APP_DIGEST	= 0x10
+	FW_RSP_GET_APP_DIGEST	= 0x0A
 };
 // clang-format on
 


### PR DESCRIPTION
FW_RSP_GET_APP_DIGEST's decimal representation is 10, not hexadecimal 0x10