### PR TITLE
Adjust and document the firmware state-machine, including USS

### DIFF
--- a/doc/system_description/software.md
+++ b/doc/system_description/software.md
@@ -84,19 +84,19 @@ will send a raw binary targeted to be loaded at `0x4001_0000` in the
 device.
 
   1. The host sends the User Supplied Secret (USS) by using the
-     `FW_CMD_LOAD_APP_SIZE` command.
+     `FW_CMD_LOAD_USS` command and gets a `FW_RSP_LOAD_USS` back.
   2. The host sends the size of the app by using the
      `FW_CMD_LOAD_APP_SIZE` command.
   3. The firmware executes `FW_CMD_LOAD_APP_SIZE` command, which
      stores the application size into `APP_SIZE`, and sets `APP_ADDR`
      to zero. A `FW_RSP_LOAD_APP_SIZE` reponse is sent back to the
      host, with the status of the action (ok/fail).
-  4. If the the host receive a sucessful command, it will send
-     multiple `FW_CMD_LOAD_APP_DATA` commands, containing the full
-     application.
+  4. If the the host receive a sucessful response, it will send
+     multiple `FW_CMD_LOAD_APP_DATA` commands, together containing the
+     full application.
   5. For each received `FW_CMD_LOAD_APP_DATA` command the firmware
      places the data into `0x4001_0000` and upwards. The firmware
-     response with `FW_RSP_LOAD_APP_DATA` response to the host for
+     replies with a `FW_RSP_LOAD_APP_DATA` response to the host for
      each received block.
   6. When the final block of the application image is received, we
      measure the application by computing a BLAKE2s digest over the


### PR DESCRIPTION
In particular, order of LOAD_USS and LOAD_APP_SIZE is not required, but the need to send both is documented. This is followed up with adjustment in the host programs' Go code, to try to reinforce this. LoadApp() will take the secretPhrase parameter (to be hashed as USS), and loadUSS() will be unexported.

Correct CMD/RSP lengths in pseudo-code.

See also: https://github.com/tillitis/tillitis-key1-apps/pull/8
