### PR TITLE
Add software reset example for the mta1 programmer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,5 @@ fp-info-cache
 *.net
 *.dsn
 *.ses
+
+__pycache__

--- a/doc/quickstart.md
+++ b/doc/quickstart.md
@@ -35,7 +35,10 @@ the touch sensor is located (next to the LED). Note that connecting
 the USB stick to the computer is not required for programming it. Note
 also that with this setup, to reset the USB stick back to firmware
 mode after loading an app, you need to unplug both the USB cable to
-the stick and the one to the programmer.
+the stick and the one to the programmer. Alternatively, you can try
+the script in `../hw/application_fpga/tools/reset-tk1` which pokes at
+the TK1 that's sitting in the jig, leaving it in firmware mode so that
+a new app can be loaded.
 
 On Linux, `lsusb` should list the connected programmer as `cafe:4004
 Blinkinlabs ICE40 programmer`. If the USB stick is also connected it

--- a/hw/application_fpga/tools/reset-tk1
+++ b/hw/application_fpga/tools/reset-tk1
@@ -1,0 +1,15 @@
+#!/bin/sh
+set -eu
+
+cd "${0%/*}"
+cd ../../boards/mta1-usb-v1/test
+
+if [ ! -e venv ]; then
+  python3 -m venv venv
+  . ./venv/bin/activate
+  pip3 install -r requirements.txt
+else
+  . ./venv/bin/activate
+fi
+
+./reset.py

--- a/hw/boards/mta1-usb-v1/test/hid_test.py
+++ b/hw/boards/mta1-usb-v1/test/hid_test.py
@@ -9,8 +9,11 @@ USB_VID = 0xcafe
 
 class ice40_flasher:
     def __init__(self):
+        self.dev = None
         for dict in hid.enumerate(USB_VID):
             self.dev = hid.Device(dict['vendor_id'], dict['product_id'])
+        if self.dev is None:
+            raise IOError("Couldn't find any hid device with vendor id 0x%x" % (USB_VID))
 
     def close(self):
         self.dev.close()

--- a/hw/boards/mta1-usb-v1/test/requirements.txt
+++ b/hw/boards/mta1-usb-v1/test/requirements.txt
@@ -1,0 +1,4 @@
+hid==1.0.5
+numpy==1.23.4
+pyserial==3.5
+pyusb==1.2.1

--- a/hw/boards/mta1-usb-v1/test/reset.py
+++ b/hw/boards/mta1-usb-v1/test/reset.py
@@ -2,12 +2,15 @@
 import hid_test
 import time
 
-def reset_mta1():
-    """ Manipulate the GPIO lines on the MTA1-USB-CH552 Programmer to issue a hardware reset to the MTA1 """
+
+def reset_tk1():
+    """Manipulate the GPIO lines on the MTA1-USB-CH552 Programmer to issue a
+    hardware reset to the TK1. The result is that TK1 again will be in firmware
+    mode, so a new app can be loaded."""
     d = hid_test.ice40_flasher()
     d.gpio_set_direction(14, True)
     d.gpio_put(14, False)
     d.gpio_set_direction(14, False)
     d.close()
 
-reset_mta1()
+reset_tk1()

--- a/hw/boards/mta1-usb-v1/test/reset.py
+++ b/hw/boards/mta1-usb-v1/test/reset.py
@@ -1,0 +1,13 @@
+#!/usr/bin/env python3
+import hid_test
+import time
+
+def reset_mta1():
+    """ Manipulate the GPIO lines on the MTA1-USB-CH552 Programmer to issue a hardware reset to the MTA1 """
+    d = hid_test.ice40_flasher()
+    d.gpio_set_direction(14, True)
+    d.gpio_put(14, False)
+    d.gpio_set_direction(14, False)
+    d.close()
+
+reset_mta1()


### PR DESCRIPTION
This adds a test script demonstrating how to use the programmer board to issue a hardware reset on a connected mta1-usb-v1 device.