### PR TITLE
fw: Introduce an explicit state machine - changes protocol!

### DIFF
--- a/doc/system_description/firmware.md
+++ b/doc/system_description/firmware.md
@@ -32,14 +32,16 @@ Commands in state `initial`:
 | *command*          | *next state*   |
 |--------------------|----------------|
 | NameVersion()      | unchanged      |
+| GetUDI()           | unchanged      |
 | LoadApp(size, uss) | `init_loading` |
 |                    |                |
 
-Commands in `initial_loading`:
+Commands in `init_loading`:
 
 | *command*          | *next state*   |
 |--------------------|----------------|
 | NameVersion()      | unchanged      |
+| GetUDI()           | unchanged      |
 | LoadApp(size, uss) | `init_loading` |
 | LoadAppData(data)  | `loading`      |
 |                    |                |
@@ -49,6 +51,7 @@ Commands in `loading`:
 | *command*          | *next state*                     |
 |--------------------|----------------------------------|
 | NameVersion()      | unchanged                        |
+| GetUDI()           | unchanged                        |
 | LoadApp(size, uss) | `init_loading`                   |
 | LoadAppData(data)  | `loading` or `run` on last chunk |
 |                    |                                  |
@@ -56,11 +59,13 @@ Commands in `loading`:
 Behaviour:
 
 - NameVersion: identifies stick.
+- GetUDI: returns the Unique Device ID with vendor id, product id,
+  revision, serial number.
 - LoadApp(size, uss): Start loading an app with this size and user
   supplied secret.
 - LoadAppData(data): Load chunk of data of app. When last data chunk
   is received we compute and return the digest.
-    
+
 ## Using QEMU
 
 Checkout the `tk1` branch of [our version of the

--- a/doc/system_description/software.md
+++ b/doc/system_description/software.md
@@ -164,17 +164,19 @@ The commands look like this:
 The responses might include a one byte status field where 0 is
 `STATUS_OK` and 1 is `STATUS_BAD`.
 
+Note that the integer types are little-endian (LE).
+
 #### `FW_CMD_NAME_VERSION` (0x01)
 
 Get the name and version of the stick.
 
 #### `FW_RSP_NAME_VERSION` (0x02)
 
-| *name*  | *size (bytes)* | *comment*       |
-|---------|----------------|-----------------|
-| name0   | 4              | ASCII           |
-| name1   | 4              | ASCII           |
-| version | 4              | Integer version |
+| *name*  | *size (bytes)* | *comment*            |
+|---------|----------------|----------------------|
+| name0   | 4              | ASCII                |
+| name1   | 4              | ASCII                |
+| version | 4              | Integer version (LE) |
 
 In a bad response the fields will be zeroed.
 
@@ -182,7 +184,7 @@ In a bad response the fields will be zeroed.
 
 | *name*       | *size (bytes)* | *comment*           |
 |--------------|----------------|---------------------|
-| size         | 4              |                     |
+| size         | 4              | Integer (LE)        |
 | uss-provided | 1              | 0 = false, 1 = true |
 | uss          | 32             | Ignored if above 0  |
 
@@ -236,10 +238,13 @@ Ask for the Unique Device Identifier (UDI) of the device.
 
 Response to `FW_CMD_GET_UDI`.
 
-| *name* | *size (bytes)* | *comment*                                       |
-|--------|----------------|-------------------------------------------------|
-| status | 1              | `STATUS_OK`/`STATUS_BAD`                        |
-| udi    | 8              | Vendor (2B), Product (1B), rev(4b), serial (4B) |
+| *name* | *size (bytes)* | *comment*                                           |
+|--------|----------------|-----------------------------------------------------|
+| status | 1              | `STATUS_OK`/`STATUS_BAD`                            |
+| udi    | 4              | Integer (LE) with Reserved (4 bit), Vendor (2 byte),|
+|        |                | Product (1 byte), Revision (4 bit)                  |
+| udi    | 4              | Integer serial number (LE)                          |
+
 
 #### Get the name and version of the device
 

--- a/hw/application_fpga/fw/tk1/main.c
+++ b/hw/application_fpga/fw/tk1/main.c
@@ -20,6 +20,7 @@ static volatile uint32_t *cdi =        (volatile uint32_t *)TK1_MMIO_TK1_CDI_FIR
 static volatile uint32_t *app_addr =   (volatile uint32_t *)TK1_MMIO_TK1_APP_ADDR;
 static volatile uint32_t *app_size =   (volatile uint32_t *)TK1_MMIO_TK1_APP_SIZE;
 static volatile uint8_t  *fw_ram =     (volatile uint8_t  *)TK1_MMIO_FW_RAM_BASE;
+static volatile uint32_t *led =        (volatile uint32_t *)TK1_MMIO_TK1_LED;
 
 #define LED_RED   (1 << TK1_MMIO_TK1_LED_R_BIT)
 #define LED_GREEN (1 << TK1_MMIO_TK1_LED_G_BIT)
@@ -172,8 +173,13 @@ int main()
 			break; // Not reached
 		}
 
-		// blocking; fw flashing white while waiting for cmd
-		uint8_t in = readbyte_ledflash(LED_WHITE, 800000);
+		uint8_t in;
+		if (state == FW_STATE_LOADING) {
+			*led = LED_WHITE;
+			in = readbyte();
+		} else {
+			in = readbyte_ledflash(LED_WHITE, 800000);
+		}
 
 		if (parseframe(in, &hdr) == -1) {
 			puts("Couldn't parse header\n");

--- a/hw/application_fpga/fw/tk1/main.c
+++ b/hw/application_fpga/fw/tk1/main.c
@@ -91,6 +91,17 @@ static void compute_cdi(uint8_t digest[32], uint8_t use_uss, uint8_t uss[32])
 	wordcpy((void *)cdi, (void *)local_cdi, 8);
 }
 
+void forever_redflash()
+{
+	int led_on = 0;
+	for (;;) {
+		*led = led_on ? LED_RED : 0;
+		for (volatile int i = 0; i < 800000; i++) {
+		}
+		led_on = !led_on;
+	}
+}
+
 enum state {
 	FW_STATE_INITIAL,
 	FW_STATE_INIT_LOADING,
@@ -163,13 +174,10 @@ int main()
 			break; // This is never reached!
 
 		default:
-			// Unknown state!?
 			puts("Unknown firmware state 0x");
 			puthex(state);
 			lf();
-
-			asm volatile("forever:;"
-				     "j forever;");
+			forever_redflash();
 			break; // Not reached
 		}
 

--- a/hw/application_fpga/fw/tk1/main.c
+++ b/hw/application_fpga/fw/tk1/main.c
@@ -246,7 +246,8 @@ int main()
 			putinthex(local_app_size);
 			lf();
 
-			if (local_app_size > TK1_APP_MAX_SIZE) {
+			if (local_app_size == 0 ||
+			    local_app_size > TK1_APP_MAX_SIZE) {
 				rsp[0] = STATUS_BAD;
 				fwreply(hdr, FW_RSP_LOAD_APP, rsp);
 				break;

--- a/hw/application_fpga/fw/tk1/proto.c
+++ b/hw/application_fpga/fw/tk1/proto.c
@@ -71,12 +71,7 @@ void fwreply(struct frame_header hdr, enum fwcmd rspcode, uint8_t *buf)
 		nbytes = 32;
 		break;
 
-	case FW_RSP_LOAD_USS:
-		len = LEN_4;
-		nbytes = 4;
-		break;
-
-	case FW_RSP_LOAD_APP_SIZE:
+	case FW_RSP_LOAD_APP:
 		len = LEN_4;
 		nbytes = 4;
 		break;
@@ -86,12 +81,7 @@ void fwreply(struct frame_header hdr, enum fwcmd rspcode, uint8_t *buf)
 		nbytes = 4;
 		break;
 
-	case FW_RSP_RUN_APP:
-		len = LEN_4;
-		nbytes = 4;
-		break;
-
-	case FW_RSP_GET_APP_DIGEST:
+	case FW_RSP_LOAD_APP_DATA_READY:
 		len = LEN_128;
 		nbytes = 128;
 		break;

--- a/hw/application_fpga/fw/tk1/proto.h
+++ b/hw/application_fpga/fw/tk1/proto.h
@@ -26,21 +26,15 @@ enum cmdlen {
 
 // clang-format off
 enum fwcmd {
-	FW_CMD_NAME_VERSION	= 0x01,
-	FW_RSP_NAME_VERSION	= 0x02,
-	FW_CMD_LOAD_APP_SIZE	= 0x03,
-	FW_RSP_LOAD_APP_SIZE	= 0x04,
-	FW_CMD_LOAD_APP_DATA	= 0x05,
-	FW_RSP_LOAD_APP_DATA	= 0x06,
-	FW_CMD_RUN_APP		= 0x07,
-	FW_RSP_RUN_APP		= 0x08,
-	FW_CMD_GET_APP_DIGEST	= 0x09,
-	FW_CMD_LOAD_USS		= 0x0a,
-	FW_RSP_LOAD_USS		= 0x0b,
-	FW_CMD_GET_UDI		= 0x0c,
-	FW_RSP_GET_UDI		= 0x0d,
-	/* ... */
-	FW_RSP_GET_APP_DIGEST	= 0x10, // encoded as 0x10 for backwards compatibility
+	FW_CMD_NAME_VERSION		= 0x01,
+	FW_RSP_NAME_VERSION		= 0x02,
+	FW_CMD_LOAD_APP			= 0x03,
+	FW_RSP_LOAD_APP			= 0x04,
+	FW_CMD_LOAD_APP_DATA		= 0x05,
+	FW_RSP_LOAD_APP_DATA		= 0x06,
+	FW_RSP_LOAD_APP_DATA_READY	= 0x07,
+	FW_CMD_GET_UDI			= 0x08,
+	FW_RSP_GET_UDI			= 0x09,
 };
 // clang-format on
 

--- a/hw/application_fpga/fw/tk1/types.h
+++ b/hw/application_fpga/fw/tk1/types.h
@@ -16,4 +16,7 @@ typedef unsigned long size_t;
 
 #define NULL ((char *)0)
 
+#define FALSE 0
+#define TRUE !FALSE
+
 #endif


### PR DESCRIPTION
We introduce an explicit state machine (see README).

With the new states we:

- combine setting size and USS to a single command. USS is now optional.
- start the device app immediatiely when having receceived the last data chunk and returning the digest.

See corresponding changes in https://github.com/tillitis/tillitis-key1-apps/pull/21

Closes #21 