### PR TITLE
build tools: Add podman support

### DIFF
--- a/contrib/Dockerfile
+++ b/contrib/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:22.10 as base
+FROM docker.io/library/ubuntu:22.10 as base
 
 RUN apt-get -qq update -y \
     && DEBIAN_FRONTEND=noninteractive \

--- a/contrib/Makefile
+++ b/contrib/Makefile
@@ -1,5 +1,22 @@
+all:
+	@echo "Build targets: "
+	@echo "build			Build an image for building tools with Docker"
+	@echo "run			Run a shell using the above image with Docker"
+	@echo "podman-build       	Build an image with podman"
+	@echo "podman-run		Run a shell using above image with podman"
+	@echo "podman-run-make		Run the above image with podman and build the FPGA bitstream"
+
 build:
-	docker build -t key1 .
+	docker build -t tkey-builder .
 
 run:
-	docker run --mount type=bind,source="`pwd`/../",target=/build -w /build -it key1 /usr/bin/bash
+	docker run --mount type=bind,source="`pwd`/../",target=/build -w /build -it tkey-builder /usr/bin/bash
+
+podman-build:
+	podman build -t tkey-builder .
+
+podman-run:
+	podman run --mount type=bind,source="`pwd`/../",target=/build -w /build -it tkey-builder /usr/bin/bash
+
+podman-run-make:
+	podman run --mount type=bind,source="`pwd`/../hw/application_fpga",target=/build -w /build -it tkey-builder make


### PR DESCRIPTION
- Add a small menu of build targets
- Add podman support, both building the image, creating a container of the image and running shell, and running make inside a podman image.

We should perhaps also add stuff like pushing to our own ghcr?