### PR TITLE
Harden firmware a bit

### DIFF
--- a/doc/system_description/software.md
+++ b/doc/system_description/software.md
@@ -78,7 +78,8 @@ Typical use scenario:
 
   1. The host sends the `FW_CMD_LOAD_APP` command with the size of the
      device app and the user-supplied secret as arguments and and gets
-     a `FW_RSP_LOAD_APP` back.
+     a `FW_RSP_LOAD_APP` back. After using this it's not possible to
+     restart the loading of a device app.
   2. If the the host receive a sucessful response, it will send
      multiple `FW_CMD_LOAD_APP_DATA` commands, together containing the
      full application.
@@ -175,28 +176,18 @@ read, the firmware executes the command.
 States:
 
 - `initial` - At start.
-- `init_loading` - Reset app digest, size, `USS` and load address.
-- `loading` - Expect more app data or a reset by `LoadApp()`.
+- `loading` - Expect app data.
 - `run` - Computes CDI and starts the device app.
+- `fail` - Stops waiting for commands, flashes LED forever.
 
 Commands in state `initial`:
 
-| *command*             | *next state*   |
-|-----------------------|----------------|
-| `FW_CMD_NAME_VERSION` | unchanged      |
-| `FW_CMD_GET_UDI`      | unchanged      |
-| `FW_CMD_LOAD_APP`     | `init_loading` |
-|                       |                |
-
-Commands in state `init_loading`:
-
-| *command*              | *next state*   |
-|------------------------|----------------|
-| `FW_CMD_NAME_VERSION`  | unchanged      |
-| `FW_CMD_GET_UDI`       | unchanged      |
-| `FW_CMD_LOAD_APP`      | `init_loading` |
-| `FW_CMD_LOAD_APP_DATA` | `loading`      |
-|                        |                |
+| *command*             | *next state* |
+|-----------------------|--------------|
+| `FW_CMD_NAME_VERSION` | unchanged    |
+| `FW_CMD_GET_UDI`      | unchanged    |
+| `FW_CMD_LOAD_APP`     | `loading`    |
+|                       |              |
 
 Commands in state `loading`:
 
@@ -204,8 +195,7 @@ Commands in state `loading`:
 |------------------------|----------------------------------|
 | `FW_CMD_NAME_VERSION`  | unchanged                        |
 | `FW_CMD_GET_UDI`       | unchanged                        |
-| `FW_CMD_LOAD_APP`      | `init_loading`                   |
-| `FW_CMD_LOAD_APP_DATA` | `loading` or `run` on last chunk |
+| `FW_CMD_LOAD_APP_DATA` | unchanged or `run` on last chunk |
 
 See below for firmware protocol definition.
 

--- a/hw/application_fpga/Makefile
+++ b/hw/application_fpga/Makefile
@@ -74,6 +74,7 @@ FIRMWARE_DEPS = \
 	$(P)/fw/tk1/lib.h \
 	$(P)/fw/tk1/proto.h \
 	$(P)/fw/tk1/assert.h \
+	$(P)/fw/tk1/led.h
 
 FIRMWARE_OBJS = \
 	$(P)/fw/tk1/main.o \
@@ -81,6 +82,7 @@ FIRMWARE_OBJS = \
 	$(P)/fw/tk1/proto.o \
 	$(P)/fw/tk1/lib.o \
 	$(P)/fw/tk1/assert.o \
+	$(P)/fw/tk1/led.o \
 	$(P)/fw/tk1/blake2s/blake2s.o
 
 TESTFW_OBJS = \

--- a/hw/application_fpga/Makefile
+++ b/hw/application_fpga/Makefile
@@ -35,7 +35,8 @@ CC = clang
 
 CFLAGS = -target riscv32-unknown-none-elf -march=rv32iczmmul -mabi=ilp32 \
    -static -std=gnu99 -Os -ffast-math -fno-common -fno-builtin-printf \
-   -fno-builtin-putchar -nostdlib -mno-relax -Wall -flto -DNOCONSOLE
+   -fno-builtin-putchar -fno-builtin-memcpy -nostdlib -mno-relax -Wall \
+   -flto -DNOCONSOLE
 
 AS = clang
 ASFLAGS = -target riscv32-unknown-none-elf -march=rv32iczmmul -mabi=ilp32 -mno-relax
@@ -71,13 +72,15 @@ FIRMWARE_DEPS = \
 	$(P)/fw/tk1_mem.h \
 	$(P)/fw/tk1/types.h \
 	$(P)/fw/tk1/lib.h \
-	$(P)/fw/tk1/proto.h
+	$(P)/fw/tk1/proto.h \
+	$(P)/fw/tk1/assert.h \
 
 FIRMWARE_OBJS = \
 	$(P)/fw/tk1/main.o \
 	$(P)/fw/tk1/start.o \
 	$(P)/fw/tk1/proto.o \
 	$(P)/fw/tk1/lib.o \
+	$(P)/fw/tk1/assert.o \
 	$(P)/fw/tk1/blake2s/blake2s.o
 
 TESTFW_OBJS = \

--- a/hw/application_fpga/fw/tk1/Makefile
+++ b/hw/application_fpga/fw/tk1/Makefile
@@ -1,5 +1,5 @@
 # Uses ../.clang-format
-FMTFILES=main.c lib.h lib.c proto.h proto.c types.h
+FMTFILES=main.c lib.h lib.c proto.h proto.c types.h assert.c assert.h
 .PHONY: fmt
 fmt:
 	clang-format --dry-run --ferror-limit=0 $(FMTFILES)

--- a/hw/application_fpga/fw/tk1/Makefile
+++ b/hw/application_fpga/fw/tk1/Makefile
@@ -1,5 +1,5 @@
 # Uses ../.clang-format
-FMTFILES=main.c lib.h lib.c proto.h proto.c types.h assert.c assert.h
+FMTFILES=main.c lib.h lib.c proto.h proto.c types.h assert.c assert.h led.c led.h
 .PHONY: fmt
 fmt:
 	clang-format --dry-run --ferror-limit=0 $(FMTFILES)

--- a/hw/application_fpga/fw/tk1/assert.c
+++ b/hw/application_fpga/fw/tk1/assert.c
@@ -1,0 +1,25 @@
+/*
+ * Copyright (C) 2022, 2023 - Tillitis AB
+ * SPDX-License-Identifier: GPL-2.0-only
+ */
+
+#include "assert.h"
+#include "lib.h"
+
+void __assert_fail(const char *__assertion, const char *__file,
+		   unsigned int __line, const char *__function)
+{
+	htif_puts("assert: ");
+	htif_puts(__assertion);
+	htif_puts(" ");
+	htif_puts(__file);
+	htif_puts(":");
+	htif_putinthex(__line);
+	htif_puts(" ");
+	htif_puts(__function);
+	htif_lf();
+
+	for (;;);
+
+	// Not reached
+}

--- a/hw/application_fpga/fw/tk1/assert.c
+++ b/hw/application_fpga/fw/tk1/assert.c
@@ -4,6 +4,7 @@
  */
 
 #include "assert.h"
+#include "led.h"
 #include "lib.h"
 
 void __assert_fail(const char *__assertion, const char *__file,
@@ -19,6 +20,6 @@ void __assert_fail(const char *__assertion, const char *__file,
 	htif_puts(__function);
 	htif_lf();
 
-	for (;;);
+	forever_redflash();
 	// Not reached
 }

--- a/hw/application_fpga/fw/tk1/assert.c
+++ b/hw/application_fpga/fw/tk1/assert.c
@@ -20,6 +20,5 @@ void __assert_fail(const char *__assertion, const char *__file,
 	htif_lf();
 
 	for (;;);
-
 	// Not reached
 }

--- a/hw/application_fpga/fw/tk1/assert.h
+++ b/hw/application_fpga/fw/tk1/assert.h
@@ -1,0 +1,16 @@
+/*
+ * Copyright (C) 2022, 2023 - Tillitis AB
+ * SPDX-License-Identifier: GPL-2.0-only
+ */
+
+#ifndef ASSERT_H
+#define ASSERT_H
+
+#define assert(expr)                                                           \
+	((expr) ? (void)(0)                                                    \
+		: __assert_fail(#expr, __FILE__, __LINE__, __func__))
+
+void __assert_fail(const char *__assertion, const char *__file,
+		   unsigned int __line, const char *__function);
+
+#endif

--- a/hw/application_fpga/fw/tk1/led.c
+++ b/hw/application_fpga/fw/tk1/led.c
@@ -1,0 +1,21 @@
+/*
+ * Copyright (C) 2022, 2023 - Tillitis AB
+ * SPDX-License-Identifier: GPL-2.0-only
+ */
+
+#include "led.h"
+#include "../tk1_mem.h"
+#include "types.h"
+
+void forever_redflash()
+{
+	static volatile uint32_t *led = (volatile uint32_t *)TK1_MMIO_TK1_LED;
+
+	int led_on = 0;
+	for (;;) {
+		*led = led_on ? LED_RED : 0;
+		for (volatile int i = 0; i < 800000; i++) {
+		}
+		led_on = !led_on;
+	}
+}

--- a/hw/application_fpga/fw/tk1/led.h
+++ b/hw/application_fpga/fw/tk1/led.h
@@ -1,0 +1,22 @@
+/*
+ * Copyright (C) 2022, 2023 - Tillitis AB
+ * SPDX-License-Identifier: GPL-2.0-only
+ */
+
+#ifndef LED_H
+#define LED_H
+
+#include "../tk1_mem.h"
+#include "types.h"
+
+// clang-format off
+static volatile uint32_t *led = (volatile uint32_t *)TK1_MMIO_TK1_LED;
+// clang-format on
+
+#define LED_RED (1 << TK1_MMIO_TK1_LED_R_BIT)
+#define LED_GREEN (1 << TK1_MMIO_TK1_LED_G_BIT)
+#define LED_BLUE (1 << TK1_MMIO_TK1_LED_B_BIT)
+#define LED_WHITE (LED_RED | LED_GREEN | LED_BLUE)
+
+void forever_redflash();
+#endif

--- a/hw/application_fpga/fw/tk1/lib.c
+++ b/hw/application_fpga/fw/tk1/lib.c
@@ -4,8 +4,8 @@
  */
 
 #include "lib.h"
-#include "types.h"
 #include "assert.h"
+#include "types.h"
 
 #if NOCONSOLE
 void htif_putc(int ch)

--- a/hw/application_fpga/fw/tk1/lib.c
+++ b/hw/application_fpga/fw/tk1/lib.c
@@ -7,33 +7,7 @@
 #include "assert.h"
 #include "types.h"
 
-#if NOCONSOLE
-void htif_putc(int ch)
-{
-}
-
-void htif_lf()
-{
-}
-
-void htif_puthex(uint8_t c)
-{
-}
-
-void htif_putinthex(const uint32_t n)
-{
-}
-
-int htif_puts(const char *s)
-{
-	return 0;
-}
-
-void htif_hexdump(uint8_t *buf, int len)
-{
-}
-
-#else
+#ifndef NOCONSOLE
 struct {
 	uint32_t arr[2];
 } volatile tohost __attribute__((section(".htif")));

--- a/hw/application_fpga/fw/tk1/lib.c
+++ b/hw/application_fpga/fw/tk1/lib.c
@@ -112,9 +112,8 @@ void htif_puthex(uint8_t c)
 
 void htif_putinthex(const uint32_t n)
 {
-	uint8_t buf[4];
+	uint8_t *buf = (uint8_t *)&n;
 
-	memcpy(buf, &n, 4);
 	htif_puts("0x");
 	for (int i = 3; i > -1; i--) {
 		htif_puthex(buf[i]);

--- a/hw/application_fpga/fw/tk1/lib.c
+++ b/hw/application_fpga/fw/tk1/lib.c
@@ -5,6 +5,7 @@
 
 #include "lib.h"
 #include "types.h"
+#include "assert.h"
 
 #if NOCONSOLE
 void htif_putc(int ch)
@@ -131,28 +132,32 @@ void *memset(void *dest, int c, unsigned n)
 	return dest;
 }
 
-__attribute__((used)) void *memcpy(void *dest, const void *src, unsigned n)
+void memcpy_s(void *dest, size_t destsize, const void *src, size_t n)
 {
+	assert(dest != NULL);
+	assert(src != NULL);
+	assert(destsize >= n);
+
 	uint8_t *src_byte = (uint8_t *)src;
 	uint8_t *dest_byte = (uint8_t *)dest;
 
 	for (int i = 0; i < n; i++) {
 		dest_byte[i] = src_byte[i];
 	}
-
-	return dest;
 }
 
-__attribute__((used)) void *wordcpy(void *dest, const void *src, unsigned n)
+void wordcpy_s(void *dest, size_t destsize, const void *src, size_t n)
 {
+	assert(dest != NULL);
+	assert(src != NULL);
+	assert(destsize >= n);
+
 	uint32_t *src_word = (uint32_t *)src;
 	uint32_t *dest_word = (uint32_t *)dest;
 
 	for (int i = 0; i < n; i++) {
 		dest_word[i] = src_word[i];
 	}
-
-	return dest;
 }
 
 int memeq(void *dest, const void *src, unsigned n)

--- a/hw/application_fpga/fw/tk1/lib.h
+++ b/hw/application_fpga/fw/tk1/lib.h
@@ -8,12 +8,22 @@
 
 #include "types.h"
 
+#ifdef NOCONSOLE
+#define htif_putc(ch)
+#define htif_lf()
+#define htif_puthex(c)
+#define htif_putinthex(n)
+#define htif_puts(s) ((int)0)
+#define htif_hexdump(buf, len)
+#else
 void htif_putc(int ch);
 void htif_lf();
 void htif_puthex(uint8_t c);
 void htif_putinthex(const uint32_t n);
 int htif_puts(const char *s);
 void htif_hexdump(uint8_t *buf, int len);
+#endif
+
 void *memset(void *dest, int c, unsigned n);
 void memcpy_s(void *dest, size_t destsize, const void *src, size_t n);
 void wordcpy_s(void *dest, size_t destsize, const void *src, size_t n);

--- a/hw/application_fpga/fw/tk1/lib.h
+++ b/hw/application_fpga/fw/tk1/lib.h
@@ -15,8 +15,8 @@ void htif_putinthex(const uint32_t n);
 int htif_puts(const char *s);
 void htif_hexdump(uint8_t *buf, int len);
 void *memset(void *dest, int c, unsigned n);
-void *memcpy(void *dest, const void *src, unsigned n);
-void *wordcpy(void *dest, const void *src, unsigned n);
+void memcpy_s(void *dest, size_t destsize, const void *src, size_t n);
+void wordcpy_s(void *dest, size_t destsize, const void *src, size_t n);
 int memeq(void *dest, const void *src, unsigned n);
 
 #endif

--- a/hw/application_fpga/fw/tk1/main.c
+++ b/hw/application_fpga/fw/tk1/main.c
@@ -244,7 +244,11 @@ int main()
 
 		memset(cmd, 0, CMDLEN_MAXBYTES);
 		// Now we know the size of the cmd frame, read it all
-		read(cmd, hdr.len);
+		if (read(cmd, CMDLEN_MAXBYTES, hdr.len) != 0) {
+			htif_puts("read: buffer overrun\n");
+			forever_redflash();
+			// Not reached
+		}
 
 		// Is it for us?
 		if (hdr.endpoint != DST_FW) {

--- a/hw/application_fpga/fw/tk1/main.c
+++ b/hw/application_fpga/fw/tk1/main.c
@@ -4,11 +4,12 @@
  */
 
 #include "../tk1_mem.h"
+#include "assert.h"
 #include "blake2s/blake2s.h"
+#include "led.h"
 #include "lib.h"
 #include "proto.h"
 #include "types.h"
-#include "assert.h"
 
 // clang-format off
 static volatile uint32_t *uds             = (volatile uint32_t *)TK1_MMIO_UDS_FIRST;
@@ -21,7 +22,6 @@ static volatile uint32_t *cdi             = (volatile uint32_t *)TK1_MMIO_TK1_CD
 static volatile uint32_t *app_addr        = (volatile uint32_t *)TK1_MMIO_TK1_APP_ADDR;
 static volatile uint32_t *app_size        = (volatile uint32_t *)TK1_MMIO_TK1_APP_SIZE;
 static volatile uint8_t  *fw_ram          = (volatile uint8_t  *)TK1_MMIO_FW_RAM_BASE;
-static volatile uint32_t *led             = (volatile uint32_t *)TK1_MMIO_TK1_LED;
 static volatile uint32_t *fw_blake2s_addr = (volatile uint32_t *)TK1_MMIO_TK1_BLAKE2S;
 static volatile uint32_t *trng_status     = (volatile uint32_t *)TK1_MMIO_TRNG_STATUS;
 static volatile uint32_t *trng_entropy    = (volatile uint32_t *)TK1_MMIO_TRNG_ENTROPY;
@@ -29,11 +29,6 @@ static volatile uint32_t *timer           = (volatile uint32_t *)TK1_MMIO_TIMER_
 static volatile uint32_t *timer_prescaler = (volatile uint32_t *)TK1_MMIO_TIMER_PRESCALER;
 static volatile uint32_t *timer_status    = (volatile uint32_t *)TK1_MMIO_TIMER_STATUS;
 static volatile uint32_t *timer_ctrl      = (volatile uint32_t *)TK1_MMIO_TIMER_CTRL;
-
-#define LED_RED   (1 << TK1_MMIO_TK1_LED_R_BIT)
-#define LED_GREEN (1 << TK1_MMIO_TK1_LED_G_BIT)
-#define LED_BLUE  (1 << TK1_MMIO_TK1_LED_B_BIT)
-#define LED_WHITE (LED_RED | LED_GREEN | LED_BLUE)
 // clang-format on
 
 struct namever {
@@ -139,17 +134,6 @@ static void compute_cdi(uint8_t digest[32], uint8_t use_uss, uint8_t uss[32])
 
 	// Only word aligned access to CDI
 	wordcpy_s((void *)cdi, 8, (void *)local_cdi, 8);
-}
-
-void forever_redflash()
-{
-	int led_on = 0;
-	for (;;) {
-		*led = led_on ? LED_RED : 0;
-		for (volatile int i = 0; i < 800000; i++) {
-		}
-		led_on = !led_on;
-	}
 }
 
 enum state {

--- a/hw/application_fpga/fw/tk1/proto.c
+++ b/hw/application_fpga/fw/tk1/proto.c
@@ -148,9 +148,15 @@ uint8_t readbyte_ledflash(int ledvalue, int loopcount)
 	}
 }
 
-void read(uint8_t *buf, size_t nbytes)
+int read(uint8_t *buf, size_t bufsize, size_t nbytes)
 {
+	if (nbytes > bufsize) {
+		return -1;
+	}
+
 	for (int n = 0; n < nbytes; n++) {
 		buf[n] = readbyte();
 	}
+
+	return 0;
 }

--- a/hw/application_fpga/fw/tk1/proto.h
+++ b/hw/application_fpga/fw/tk1/proto.h
@@ -56,6 +56,6 @@ void writebyte(uint8_t b);
 void write(uint8_t *buf, size_t nbytes);
 uint8_t readbyte();
 uint8_t readbyte_ledflash(int ledvalue, int loopcount);
-void read(uint8_t *buf, size_t nbytes);
+int read(uint8_t *buf, size_t bufsize, size_t nbytes);
 
 #endif

--- a/hw/application_fpga/fw/tk1/proto.h
+++ b/hw/application_fpga/fw/tk1/proto.h
@@ -35,6 +35,7 @@ enum fwcmd {
 	FW_RSP_LOAD_APP_DATA_READY	= 0x07,
 	FW_CMD_GET_UDI			= 0x08,
 	FW_RSP_GET_UDI			= 0x09,
+	FW_CMD_MAX                      = 0x0a,
 };
 // clang-format on
 


### PR DESCRIPTION
- We introduce new memory functions `memcpy_s()` and `wordcpy_s()` which takes destination buffer size.
- `read()` also gets a destination buffer size.
- We remove unnecessary memcpy() and add `-fno-builtin-memcpy`.
- We introduce `assert()` which aborts to `forever_ledflash` if an expression doesn't hold true.
- If we don't have a console we hide all the HTIF console functions better, not even using dummy functions.
- Since UDS is now byte readable we use it directly in the BLAKE2s functions instead of copying to fw_ram.

Use qemu branch tk1-byte-addressable for testing and please confirm that it works on real hardware.