### PR TITLE
Include debug symbols in the ELF

### DIFF
--- a/hw/application_fpga/Makefile
+++ b/hw/application_fpga/Makefile
@@ -36,7 +36,7 @@ CC = clang
 CFLAGS = -target riscv32-unknown-none-elf -march=rv32iczmmul -mabi=ilp32 \
    -static -std=gnu99 -O2 -ffast-math -fno-common -fno-builtin-printf \
    -fno-builtin-putchar -fno-builtin-memcpy -nostdlib -mno-relax -Wall \
-   -flto -DNOCONSOLE
+   -flto -g -DNOCONSOLE
 
 AS = clang
 ASFLAGS = -target riscv32-unknown-none-elf -march=rv32iczmmul -mabi=ilp32 -mno-relax


### PR DESCRIPTION
Let's include debug symbols in the ELF binaries so we can use it with GDB easier.