### PR TITLE
Verilog 2001 rule; use wires for assignments, not registers.

### DIFF
--- a/hw/application_fpga/rtl/fw_ram.v
+++ b/hw/application_fpga/rtl/fw_ram.v
@@ -35,7 +35,7 @@ module fw_ram(
   reg [31 : 0] mem_read_data0;
   reg [31 : 0] mem_read_data1;
   reg          ready_reg;
-  reg          fw_app_cs;
+  wire         fw_app_cs;
   reg          bank0;
   reg          bank1;
 


### PR DESCRIPTION
Verilog 2001 rule; use wires for assignments, not registers.
    
Increase verilog source code compatibility with Lattice Diamond 3.12.
    
Address errors like these:
    
```
      2049990 ERROR - tillitis-key1/hw/application_fpga/rtl/fw_ram.v
      (VERI-1195) concurrent assignment to a non-net 'fw_app_cs' is
      not permitted
```

Tool drop down menu supports either System Verilog, Verilog 2001, Verilog 95, with Verilog 2001 being default.
(No Verilog 2005 in drop down menu, even if old PDFs does say Verilog 2005 is supported...)
    
Patch tested as follows:
    
```
      docker run -it -v$PWD:/opt/src ghcr.io/tillitis/tkey-builder:2
      bash -c
        "cp -r /opt/src /opt/build &&
        cd /opt/build/hw/application_fpga &&
        make clean &&
        make lint &&
        make all"
```