### PR TITLE
Explicity make uart_core.rx_data a wire

### DIFF
--- a/hw/application_fpga/core/uart/rtl/uart_core.v
+++ b/hw/application_fpga/core/uart/rtl/uart_core.v
@@ -61,7 +61,7 @@ module uart_core(
 
                  // Internal receive interface.
                  output wire         rxd_syn,
-                 output [7 : 0]      rxd_data,
+                 output wire [7 : 0] rxd_data,
                  input wire          rxd_ack,
 
                  // Internal transmit interface.


### PR DESCRIPTION
Fixes error messages like these in Lattice Diamond 3.12 / Verilog 2001:

```
    (VERI-1906) net type must be explicitly specified for `rx_data`
    when default_nettype is none
```
    
```
    (VERI-1195) concurrent assignment to a non-net `rx_data` is not
    permitted
```

Fix tested through;

```
  docker run --rm -it -v$PWD:/opt/src:ro ghcr.io/tillitis/tkey-builder:2
    bash -c  
      "cp -r /opt/src /opt/build && 
       cd /opt/build/hw/application_fpga && 
       make clean &&
       make lint &&
       make all"
```