### PR TITLE
Update CI action to checkout@v4

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,7 +16,7 @@ jobs:
       image: ghcr.io/tillitis/tkey-builder:2
     steps:
       - name: checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           # fetch-depth: 0
           persist-credentials: false


### PR DESCRIPTION
checkout@v3 is being deprecated. 