### PR TITLE
Build tp1 firmware in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -45,6 +45,10 @@ jobs:
         working-directory: hw/boards/mta1-usb-v1/ch552_fw
         run: make
 
+      - name: compile tp1 firmware
+        working-directory: hw/boards/tp1/firmware
+        run: ./build.sh
+
       - name: make production test gateware
         working-directory: hw/production_test/application_fpga_test_gateware
         run: make


### PR DESCRIPTION
closes #96 

Depends on a tkey-builder with pico-sdk 1.5.1, see: #190 
Need to build and push a tkey-builder:4, probably, and update in this branch to use :4.