### PR TITLE
tkey-builder: Include clang-tidy & splint

### DIFF
--- a/contrib/Dockerfile
+++ b/contrib/Dockerfile
@@ -8,6 +8,7 @@ RUN apt-get -qq update -y \
                ca-certificates \
                clang \
                clang-format \
+               clang-tidy \
                cmake \
                flex \
                gawk \
@@ -41,6 +42,7 @@ RUN apt-get -qq update -y \
                vim \
                xdot \
                sdcc \
+               splint \               
                cmake \
                gcc-arm-none-eabi \
                libnewlib-arm-none-eabi \


### PR DESCRIPTION
To be able to run statical analysis on source, include clang-tidy and splint (see make check) in tkey-builder.