### PR TITLE
Client based system reset

### DIFF
--- a/hw/application_fpga/data/application_fpga_tk1.pcf
+++ b/hw/application_fpga/data/application_fpga_tk1.pcf
@@ -15,7 +15,7 @@
 set_io interface_rx 26
 set_io interface_tx 25
 # set_io interface_cts 27
-# set_io interface_rts 28
+set_io interface_rts 28
 
 
 # Touch sense.

--- a/hw/application_fpga/rtl/application_fpga.v
+++ b/hw/application_fpga/rtl/application_fpga.v
@@ -142,6 +142,7 @@ module application_fpga(
   wire          force_trap;
   wire [14 : 0] ram_aslr;
   wire [31 : 0] ram_scramble;
+  wire          tk1_sys_reset;
   /* verilator lint_on UNOPTFLAT */
 
 
@@ -150,7 +151,7 @@ module application_fpga(
   //----------------------------------------------------------------
   clk_reset_gen #(.RESET_CYCLES(200))
   reset_gen_inst(
-                 .host_reset(interface_rts),
+                 .sys_reset(tk1_sys_reset),
                  .clk(clk),
                  .rst_n(reset_n)
                  );
@@ -321,6 +322,9 @@ module application_fpga(
 
                .ram_aslr(ram_aslr),
 	       .ram_scramble(ram_scramble),
+
+	       .external_reset(interface_rts),
+	       .sys_reset(tk1_sys_reset),
 
                .led_r(led_r),
                .led_g(led_g),

--- a/hw/application_fpga/rtl/application_fpga.v
+++ b/hw/application_fpga/rtl/application_fpga.v
@@ -19,6 +19,7 @@
 module application_fpga(
                         output wire interface_rx,
                         input wire  interface_tx,
+                        input wire  interface_rts,
 
 			input wire  touch_event,
 
@@ -148,7 +149,11 @@ module application_fpga(
   // Module instantiations.
   //----------------------------------------------------------------
   clk_reset_gen #(.RESET_CYCLES(200))
-  reset_gen_inst(.clk(clk), .rst_n(reset_n));
+  reset_gen_inst(
+                 .host_reset(interface_rts),
+                 .clk(clk),
+                 .rst_n(reset_n)
+                 );
 
 
   picorv32 #(

--- a/hw/application_fpga/rtl/clk_reset_gen.v
+++ b/hw/application_fpga/rtl/clk_reset_gen.v
@@ -21,7 +21,7 @@
 
 module clk_reset_gen #(parameter RESET_CYCLES = 200)
   (
-   input wire  host_reset,
+   input wire  sys_reset,
    output wire clk,
    output wire rst_n
    );
@@ -37,7 +37,7 @@ module clk_reset_gen #(parameter RESET_CYCLES = 200)
   reg         rst_n_reg = 1'h0;
   reg         rst_n_new;
 
-  reg [1 : 0] host_reset_sample_reg = 2'h0;
+  reg         sys_reset_reg;
 
   wire        hfosc_clk;
   wire        pll_clk;
@@ -102,8 +102,8 @@ module clk_reset_gen #(parameter RESET_CYCLES = 200)
   //----------------------------------------------------------------
     always @(posedge clk)
       begin : reg_update
-        rst_n_reg             <= rst_n_new;
-        host_reset_sample_reg <= {host_reset_sample_reg[0], host_reset};
+        rst_n_reg     <= rst_n_new;
+        sys_reset_reg <= sys_reset;
 
         if (rst_ctr_we)
           rst_ctr_reg <= rst_ctr_new;
@@ -118,8 +118,8 @@ module clk_reset_gen #(parameter RESET_CYCLES = 200)
   // logic is active, and the reset is being asserted for
   // RESET_CYCLES. Then the default reset reg value is applied.
   //
-  // When a second reset is requested from the host we
-  // reset the counter. This activates the counter logic.
+  // When a system reset is requested we reset the counter.
+  // This activates the counter logic and the reset is asserted.
   //----------------------------------------------------------------
   always @*
     begin : rst_logic
@@ -133,7 +133,7 @@ module clk_reset_gen #(parameter RESET_CYCLES = 200)
         rst_ctr_we  = 1'h1;
       end
 
-      if (host_reset_sample_reg[1]) begin
+      if (sys_reset_reg) begin
         rst_ctr_new = 8'h0;
         rst_ctr_we  = 1'h1;
       end

--- a/hw/application_fpga/rtl/clk_reset_gen.v
+++ b/hw/application_fpga/rtl/clk_reset_gen.v
@@ -18,6 +18,7 @@
 
 module clk_reset_gen #(parameter RESET_CYCLES = 200)
   (
+   input wire  host_reset,
    output wire clk,
    output wire rst_n
    );
@@ -32,6 +33,8 @@ module clk_reset_gen #(parameter RESET_CYCLES = 200)
 
   reg         rst_n_reg = 1'h0;
   reg         rst_n_new;
+
+  reg [1 : 0] host_reset_sample_reg = 2'h0;
 
   wire        hfosc_clk;
   wire        pll_clk;
@@ -93,7 +96,9 @@ module clk_reset_gen #(parameter RESET_CYCLES = 200)
   //----------------------------------------------------------------
     always @(posedge clk)
       begin : reg_update
-        rst_n_reg <= rst_n_new;
+        rst_n_reg                <= rst_n_new;
+        host_reset_sample_reg[0] <= host_reset;
+        host_reset_sample_reg[1] <= host_reset_sample_reg[0];
 
         if (rst_ctr_we)
           rst_ctr_reg <= rst_ctr_new;
@@ -114,6 +119,12 @@ module clk_reset_gen #(parameter RESET_CYCLES = 200)
         rst_ctr_new = rst_ctr_reg + 1'h1;
         rst_ctr_we  = 1'h1;
       end
+
+      if (host_reset_sample_reg[1]) begin
+        rst_n_new   = 1'h0;
+      end
+
+
     end
 
 endmodule // reset_gen

--- a/hw/application_fpga/tb/application_fpga_vsim.v
+++ b/hw/application_fpga/tb/application_fpga_vsim.v
@@ -36,6 +36,7 @@ module application_fpga(
 
                         output wire          interface_rx,
                         input wire           interface_tx,
+                        input wire           interface_rts,
 
 			input wire           touch_event,
 


### PR DESCRIPTION
This feature adds the ability for the application FPGA to receive an external request to perform an internal HW reset, thereby return to FW mode and reboot. The feature also includes a reset persistent reset status, allowing the FW to determine the reason for the boot - cold boot or externally triggered boot.

The external signal is connected to the CH552 which, with an updated FW, will be able to receive a reset request from the client, and send it to the FPGA.

This fixes issue #199.