### PR TITLE
Add API functionality to disable CDI access

### DIFF
--- a/hw/application_fpga/core/tk1/rtl/tk1.v
+++ b/hw/application_fpga/core/tk1/rtl/tk1.v
@@ -75,7 +75,6 @@ module tk1(
 
   localparam ADDR_CDI_FIRST     = 8'h20;
   localparam ADDR_CDI_LAST      = 8'h27;
-  localparam ADDR_CDI_DONE      = 8'h28;
 
   localparam ADDR_UDI_FIRST     = 8'h30;
   localparam ADDR_UDI_LAST      = 8'h31;
@@ -436,13 +435,9 @@ module tk1(
             end
 	  end
 
-	  if ((address >= ADDR_CDI_FIRST) && (address <= ADDR_CDI_LAST)) begin
-	    if (!switch_app_reg) begin
-	      cdi_mem_we = 1'h1;
-	    end
-	  end
-
-	  if (address == ADDR_CDI_DONE) begin
+	  if ((address >= ADDR_CDI_FIRST) && (address <= ADDR_CDI_LAST) & !switch_app_reg ) begin
+	    cdi_mem_we = 1'h1;
+	  end else begin
 	    cdi_access_we = 1'h1;
 	  end
 


### PR DESCRIPTION
This PR adds the ability for apps to lock down CDI access, limiting exposure to CDI by other apps, mem leaks etc. Basically the CDI can be read until a write to ADDR_CDI_DONE is performed. In order to be able to read again, the TKey device must be reset. This PR provides the functionality requested in https://github.com/tillitis/tillitis-key1/issues/186