### PR TITLE
CI: move check-hash to separate job.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -62,10 +62,40 @@ jobs:
         working-directory: hw/application_fpga
         run: make all
 
-      - name: check matching hashes for firmware.bin & application_fpga.bin
-        working-directory: hw/application_fpga
-        run: make check-binary-hashes
+      - name: Cache binaries
+        uses: actions/cache@v4
+        with:
+          path: |
+            hw/application_fpga/application_fpga.bin
+            hw/application_fpga/firmware.bin
+          key: ${{ runner.os }}-build-${{ github.sha }}
+          restore-keys: ${{ runner.os }}-build-
+
 
       # TODO? first deal with hw/boards/ and hw/production_test/
       # - name: check for SPDX tags
       #   run: ./LICENSES/spdx-ensure
+
+  check-hashes:
+    needs: ci
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/tillitis/tkey-builder:4
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Retrieve binaries from cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            hw/application_fpga/application_fpga.bin
+            hw/application_fpga/firmware.bin
+          key: ${{ runner.os }}-build-${{ needs.build.outputs.commit_sha }}
+          restore-keys: ${{ runner.os }}-build-
+
+      - name: check matching hashes for firmware.bin & application_fpga.bin
+        working-directory: hw/application_fpga
+        run: make check-binary-hashes


### PR DESCRIPTION
- This makes it easier to see if CI fails on hashes (which might be expected during development) or something else.