### PR TITLE
FPGA: Add sim model of udi_rom

### DIFF
--- a/hw/application_fpga/core/tk1/tb/udi_rom_sim.v
+++ b/hw/application_fpga/core/tk1/tb/udi_rom_sim.v
@@ -1,0 +1,36 @@
+//======================================================================
+//
+// udi_rom_sim.v
+// ---------
+// Simulation version of the UDI ROM.
+//
+//
+// Author: Joachim Strömbergson.
+// Copyright (C) 2023 - Tillitis AB
+// SPDX-License-Identifier: GPL-2.0-only
+//
+//======================================================================
+
+module udi_rom (
+		input wire [0:0] addr,
+		output wire [31:0] data
+		);
+
+  reg [31 : 0] tmp_data;
+  assign data = tmp_data;
+
+  always @*
+    begin : addr_mux
+      if (addr) begin
+	tmp_data = 32'h04050607;
+      end
+      else begin
+	tmp_data = 32'h00010203;
+      end
+    end
+
+endmodule // udi_rom
+
+//======================================================================
+// EOF udi_rom_sim.v
+//======================================================================

--- a/hw/application_fpga/core/tk1/toolruns/Makefile
+++ b/hw/application_fpga/core/tk1/toolruns/Makefile
@@ -12,7 +12,7 @@
 #===================================================================
 
 TOP_SRC=../rtl/tk1.v
-TB_TOP_SRC =../tb/tb_tk1.v ../tb/sb_rgba_drv.v
+TB_TOP_SRC =../tb/tb_tk1.v ../tb/sb_rgba_drv.v ../tb/udi_rom_sim.v
 
 CC = iverilog
 CC_FLAGS = -Wall


### PR DESCRIPTION
This PR adds a simulation model of the udi_rom. This allows us to build the testbench and simulated the tk1 core. This PR does not change the actual FPGA design.