### PR TITLE
Fix tk1 lint

### DIFF
--- a/hw/application_fpga/core/tk1/tb/sb_rgba_drv.v
+++ b/hw/application_fpga/core/tk1/tb/sb_rgba_drv.v
@@ -16,24 +16,30 @@
 `default_nettype none
 
 module SB_RGBA_DRV (
-                 output wire RGB0,
-                 output wire RGB1,
-                 output wire RGB2,
-                 input wire RGBLEDEN,
-                 input wire RGB0PWM,
-                 input wire RGB1PWM,
-                 input wire RGB2PWM,
-                 input wire CURREN
-		);
+                    input wire RGBLEDEN,
+                    input wire RGB0PWM,
+                    input wire RGB1PWM,
+                    input wire RGB2PWM,
 
+		    /* verilator lint_off UNUSEDSIGNAL */
+                    input wire CURREN,
+		    /* verilator lint_on UNUSEDSIGNAL */
+
+                    output wire RGB0,
+                    output wire RGB1,
+                    output wire RGB2
+		   );
+
+  /* verilator lint_off UNUSEDPARAM */
   parameter CURRENT_MODE = 1;
   parameter RGB0_CURRENT = 8'h0;
   parameter RGB1_CURRENT = 8'h0;
   parameter RGB2_CURRENT = 8'h0;
+  /* verilator lint_on UNUSEDPARAM */
 
-  assign RGB0 = RGB0PWM;
-  assign RGB1 = RGB1PWM;
-  assign RGB2 = RGB2PWM;
+  assign RGB0 = RGB0PWM & RGBLEDEN;
+  assign RGB1 = RGB1PWM & RGBLEDEN;
+  assign RGB2 = RGB2PWM & RGBLEDEN;
 
 endmodule // SB_RGBA_DRV
 

--- a/hw/application_fpga/core/tk1/toolruns/Makefile
+++ b/hw/application_fpga/core/tk1/toolruns/Makefile
@@ -13,6 +13,7 @@
 
 TOP_SRC=../rtl/tk1.v
 TB_TOP_SRC =../tb/tb_tk1.v ../tb/sb_rgba_drv.v ../tb/udi_rom_sim.v
+LINT_SRC=../rtl/tk1.v ../tb/sb_rgba_drv.v ../tb/udi_rom_sim.v
 
 CC = iverilog
 CC_FLAGS = -Wall
@@ -32,8 +33,8 @@ sim-top: top.sim
 	./top.sim
 
 
-lint-top:  $(TOP_SRC)
-	$(LINT) $(LINT_FLAGS) $(TOP_SRC)
+lint-top:  $(LINT_SRC)
+	$(LINT) $(LINT_FLAGS) $(LINT_SRC)
 
 
 clean:


### PR DESCRIPTION
This PR fixes linting of the tk1 core. It adds the udi_rom and sb_rbga_led simulation models used to replace the Lattice core instantiations done in the RTL. We also add ignore-pragmas to disable lint warnings on things not supported in the sim model of the rgba core.