### PR TITLE
fpga: Cleanup testbench and testbench build

### DIFF
--- a/hw/application_fpga/core/tk1/rtl/tk1_spi_master.v
+++ b/hw/application_fpga/core/tk1/rtl/tk1_spi_master.v
@@ -229,7 +229,6 @@ module tk1_spi_master(
       spi_ctrl_new    = CTRL_IDLE;
       spi_ctrl_we     = 1'h0;
 
-
       case (spi_ctrl_reg)
         CTRL_IDLE: begin
           if (spi_start) begin
@@ -244,14 +243,14 @@ module tk1_spi_master(
 	end
 
 	CTRL_POS_FLANK: begin
-	  spi_rx_data_nxt = 1'h1;
 	  spi_csk_new     = 1'h1;
 	  spi_csk_we      = 1'h1;
-	  spi_ctrl_new      = CTRL_NEG_FLANK;
-	  spi_ctrl_we       = 1'h1;
+	  spi_ctrl_new    = CTRL_NEG_FLANK;
+	  spi_ctrl_we     = 1'h1;
 	end
 
 	CTRL_NEG_FLANK: begin
+	  spi_tx_data_nxt = 1'h1;
 	  spi_csk_new  = 1'h0;
 	  spi_csk_we   = 1'h1;
 	  spi_ctrl_new = CTRL_NEXT;
@@ -259,6 +258,7 @@ module tk1_spi_master(
 	end
 
 	CTRL_NEXT: begin
+	  spi_rx_data_nxt = 1'h1;
 	  if (spi_bit_ctr_reg == 3'h7) begin
 	    spi_ready_new = 1'h1;
 	    spi_ready_we  = 1'h1;
@@ -266,7 +266,6 @@ module tk1_spi_master(
 	    spi_ctrl_we   = 1'h1;
 	  end
 	  else begin
-	    spi_tx_data_nxt = 1'h1;
 	    spi_bit_ctr_inc = 1'h1;
 	    spi_ctrl_new    = CTRL_POS_FLANK;
 	    spi_ctrl_we     = 1'h1;

--- a/hw/application_fpga/core/tk1/tb/tb_tk1_spi_master.v
+++ b/hw/application_fpga/core/tk1/tb/tb_tk1_spi_master.v
@@ -155,9 +155,6 @@ module tb_tk1_spi_master();
 
       $display("");
       $display("Internal state:");
-      $display("spi_clk_ctr_rst: 0x%1x, spi_clk_ctr_reg: 0x%02x",
-	       dut.spi_clk_ctr_rst, dut.spi_clk_ctr_reg);
-      $display("");
       $display("spi_bit_ctr_rst: 0x%1x, spi_bit_ctr_inc: 0x%1x, spi_bit_ctr_reg: 0x%02x",
 	       dut.spi_bit_ctr_rst, dut.spi_bit_ctr_inc, dut.spi_bit_ctr_reg);
       $display("");
@@ -445,9 +442,9 @@ module tb_tk1_spi_master();
       xfer_byte(8'h00, rx_byte);
       $display("--- tc_get_device_id: Got ID 0x%02x after dummy byte 6", rx_byte);
       xfer_byte(8'h00, rx_byte);
-      $display("--- tc_get_device_id: Got ID 0x%02x after dummy byte 6", rx_byte);
+      $display("--- tc_get_device_id: Got ID 0x%02x after dummy byte 7", rx_byte);
       xfer_byte(8'h00, rx_byte);
-      $display("--- tc_get_device_id: Got ID 0x%02x after dummy byte 6", rx_byte);
+      $display("--- tc_get_device_id: Got ID 0x%02x after dummy byte 8", rx_byte);
 
       disable_spi();
       #(2 * CLK_PERIOD);
@@ -516,7 +513,7 @@ module tb_tk1_spi_master();
 
       $display("");
       $display("--- tc_get_unique_device_id: Read out unique id from the memory");
-      $display("--- tc_get_unique_device_id: Expected result: 0x0102030405060708");
+      $display("--- tc_get_unique_device_id: Expected result: 0xdc02030405060708");
 
       #(2 * CLK_PERIOD);
       enable_spi();


### PR DESCRIPTION
      Update name of Winbond model
      Remove DUT variables from state display that was
      removed as part of performance fix

## Description
This PR fix regressions in testbench build and the testbench itself:

1. Update the name of the Winbond SPI memory model that one now gets when downloading the model from Windbond website. Both in Makefile and the testbench
2. Remove the clock counter control signal and register from the DUT state display in the testbench. These were removed as part of RTL update to maximize the SPI speed. Basically we don't run below what we can get with the given clock frequency.

Fixes # (issues)
No issue assigned before. Found during other bug hunt.

## Type of change

Please tick any that are relevant to this PR and remove any that aren't.

- [X] Bugfix (non breaking change which resolve an issue)
- [ ] Feature (non breaking change which adds functionality)
- [ ] Breaking Change (a change which would cause existing functionality to not work as expected)
- [ ] Documentation (a change to documentation)

## Submission checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my changes
- [ ] I have tested and verified my changes on target
- [ ] My changes are well written and CI is passing
- [ ] I have squashed my work to relevant commits and rebased on main for linear history
- [ ] I have added a "Co-authored-by: x" if several people contributed, either pair programming or by squashing commits from different authors.
- [ ] I have updated the documentation where relevant (readme, dev.tillitis.se etc.)
- [ ] QEMU is updated to reflect changes
