### PR TITLE
fpga: Fix nits in constant value specification

### DIFF
--- a/hw/application_fpga/core/tk1/rtl/tk1.v
+++ b/hw/application_fpga/core/tk1/rtl/tk1.v
@@ -392,7 +392,7 @@ module tk1(
       force_trap_set = 1'h0;
 
 	if (cpu_valid) begin
-	  if (cpu_addr[31 : 30] == 2'h01 & |cpu_addr[29 : 17]) begin
+	  if (cpu_addr[31 : 30] == 2'h1 & |cpu_addr[29 : 17]) begin
 	      force_trap_set = 1'h1;
 	  end
 


### PR DESCRIPTION
      Remove the preceeding zero in the constant expression
      that cause the simulator to warn about incorrect
      bit size.

## Description
When building the tk1 simulation target, the simulator complains that the constant value given doesn't match the specified size of the constant. The problem is that 'h01' is not seen by the simulator as being two bits. One could possibly have used binary format instead of hex format. But 'h1' removes the warning.

Fixes # (issues)
No previous issue exists.

## Type of change

Please tick any that are relevant to this PR and remove any that aren't.

- [X] Bugfix (non breaking change which resolve an issue)
- [ ] Feature (non breaking change which adds functionality)
- [ ] Breaking Change (a change which would cause existing functionality to not work as expected)
- [ ] Documentation (a change to documentation)

## Submission checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my changes
- [ ] I have tested and verified my changes on target
- [x] My changes are well written and CI is passing
- [x] I have squashed my work to relevant commits and rebased on main for linear history
- [ ] I have added a "Co-authored-by: x" if several people contributed, either pair programming or by squashing commits from different authors.
- [ ] I have updated the documentation where relevant (readme, dev.tillitis.se etc.)
- [ ] QEMU is updated to reflect changes
