### PR TITLE
Fw ram 4k poc

### DIFF
--- a/hw/application_fpga/rtl/application_fpga.v
+++ b/hw/application_fpga/rtl/application_fpga.v
@@ -392,7 +392,7 @@ module application_fpga(
 
       fw_ram_cs           = 1'h0;
       fw_ram_we           = cpu_wstrb;
-      fw_ram_address      = cpu_addr[10 : 2];
+      fw_ram_address      = cpu_addr[11 : 2];
       fw_ram_write_data   = cpu_wdata;
 
       trng_cs             = 1'h0;

--- a/hw/application_fpga/rtl/application_fpga.v
+++ b/hw/application_fpga/rtl/application_fpga.v
@@ -127,7 +127,7 @@ module application_fpga(
 
   reg           fw_ram_cs;
   reg  [3 : 0]  fw_ram_we;
-  reg  [8 : 0]  fw_ram_address;
+  reg  [9 : 0]  fw_ram_address;
   reg  [31 : 0] fw_ram_write_data;
   wire [31 : 0] fw_ram_read_data;
   wire          fw_ram_ready;

--- a/hw/application_fpga/rtl/fw_ram.v
+++ b/hw/application_fpga/rtl/fw_ram.v
@@ -2,7 +2,7 @@
 //
 // fw_ram.v
 // --------
-// A 512 x 32 RAM (2048 bytes) for use by the FW. The memory has
+// A 1024 x 32 bit RAM (4096 bytes) for use by the FW. The memory has
 // support for mode based access control.
 //
 // Author: Joachim Strombergson
@@ -21,7 +21,7 @@ module fw_ram(
 
               input  wire          cs,
 	      input  wire [3 : 0]  we,
-	      input  wire [8 : 0]  address,
+	      input  wire [9 : 0]  address,
 	      input  wire [31 : 0] write_data,
 	      output wire [31 : 0] read_data,
 	      output wire          ready
@@ -34,10 +34,14 @@ module fw_ram(
   reg [31 : 0] tmp_read_data;
   reg [31 : 0] mem_read_data0;
   reg [31 : 0] mem_read_data1;
+  reg [31 : 0] mem_read_data2;
+  reg [31 : 0] mem_read_data3;
   reg          ready_reg;
   wire         fw_app_cs;
   reg          bank0;
   reg          bank1;
+  reg          bank2;
+  reg          bank3;
 
 
   //----------------------------------------------------------------
@@ -51,6 +55,7 @@ module fw_ram(
   //----------------------------------------------------------------
   // Block RAM instances.
   //----------------------------------------------------------------
+  // Bank0
   SB_RAM40_4K fw_ram0_0(
 			.RDATA(mem_read_data0[15 : 0]),
 			.RADDR({3'h0, address[7 : 0]}),
@@ -63,7 +68,7 @@ module fw_ram(
 			.WDATA(write_data[15 : 0]),
 			.WE((|we & fw_app_cs & bank0)),
 			.MASK({{8{~we[1]}}, {8{~we[0]}}})
-		       );
+			);
 
   SB_RAM40_4K fw_ram0_1(
 			.RDATA(mem_read_data0[31 : 16]),
@@ -77,9 +82,9 @@ module fw_ram(
 			.WDATA(write_data[31 : 16]),
 			.WE((|we & fw_app_cs & bank0)),
 			.MASK({{8{~we[3]}}, {8{~we[2]}}})
-		       );
+			);
 
-
+  // Bank1
   SB_RAM40_4K fw_ram1_0(
 			.RDATA(mem_read_data1[15 : 0]),
 			.RADDR({3'h0, address[7 : 0]}),
@@ -95,18 +100,76 @@ module fw_ram(
 		       );
 
   SB_RAM40_4K fw_ram1_1(
-		      .RDATA(mem_read_data1[31 : 16]),
-		      .RADDR({3'h0, address[7 : 0]}),
-		      .RCLK(clk),
-		      .RCLKE(1'h1),
-		      .RE(fw_app_cs & bank1),
-		      .WADDR({3'h0, address[7 : 0]}),
-		      .WCLK(clk),
-		      .WCLKE(1'h1),
-		      .WDATA(write_data[31 : 16]),
-		      .WE((|we & fw_app_cs & bank1)),
-		      .MASK({{8{~we[3]}}, {8{~we[2]}}})
-		     );
+			.RDATA(mem_read_data1[31 : 16]),
+			.RADDR({3'h0, address[7 : 0]}),
+			.RCLK(clk),
+			.RCLKE(1'h1),
+			.RE(fw_app_cs & bank1),
+			.WADDR({3'h0, address[7 : 0]}),
+			.WCLK(clk),
+			.WCLKE(1'h1),
+			.WDATA(write_data[31 : 16]),
+			.WE((|we & fw_app_cs & bank1)),
+			.MASK({{8{~we[3]}}, {8{~we[2]}}})
+			);
+
+  // Bank2
+  SB_RAM40_4K fw_ram2_0(
+			.RDATA(mem_read_data2[15 : 0]),
+			.RADDR({3'h0, address[7 : 0]}),
+			.RCLK(clk),
+			.RCLKE(1'h1),
+			.RE(fw_app_cs & bank2),
+			.WADDR({3'h0, address[7 : 0]}),
+			.WCLK(clk),
+			.WCLKE(1'h1),
+			.WDATA(write_data[15 : 0]),
+			.WE((|we & fw_app_cs & bank2)),
+			.MASK({{8{~we[1]}}, {8{~we[0]}}})
+			);
+
+  SB_RAM40_4K fw_ram2_1(
+			.RDATA(mem_read_data2[31 : 16]),
+			.RADDR({3'h0, address[7 : 0]}),
+			.RCLK(clk),
+			.RCLKE(1'h1),
+			.RE(fw_app_cs & bank2),
+			.WADDR({3'h0, address[7 : 0]}),
+			.WCLK(clk),
+			.WCLKE(1'h1),
+			.WDATA(write_data[31 : 16]),
+			.WE((|we & fw_app_cs & bank2)),
+			.MASK({{8{~we[3]}}, {8{~we[2]}}})
+			);
+
+  // Bank3
+  SB_RAM40_4K fw_ram3_0(
+			.RDATA(mem_read_data3[15 : 0]),
+			.RADDR({3'h0, address[7 : 0]}),
+			.RCLK(clk),
+			.RCLKE(1'h1),
+			.RE(fw_app_cs & bank3),
+			.WADDR({3'h0, address[7 : 0]}),
+			.WCLK(clk),
+			.WCLKE(1'h1),
+			.WDATA(write_data[15 : 0]),
+			.WE((|we & fw_app_cs & bank3)),
+			.MASK({{8{~we[1]}}, {8{~we[0]}}})
+			);
+
+  SB_RAM40_4K fw_ram3_1(
+			.RDATA(mem_read_data3[31 : 16]),
+			.RADDR({3'h0, address[7 : 0]}),
+			.RCLK(clk),
+			.RCLKE(1'h1),
+			.RE(fw_app_cs & bank3),
+			.WADDR({3'h0, address[7 : 0]}),
+			.WCLK(clk),
+			.WCLKE(1'h1),
+			.WDATA(write_data[31 : 16]),
+			.WE((|we & fw_app_cs & bank3)),
+			.MASK({{8{~we[3]}}, {8{~we[2]}}})
+			);
 
   //----------------------------------------------------------------
   // reg_update
@@ -129,17 +192,34 @@ module fw_ram(
     begin : rw_mux;
       bank0         = 1'h0;
       bank1         = 1'h0;
-      tmp_read_data = 32'h0;
+      bank2         = 1'h0;
+      bank3         = 1'h0;
 
       if (fw_app_cs) begin
-	if (address[8]) begin
-	  bank1 = 1'h1;
-	  tmp_read_data = mem_read_data1;
-	end
-	else begin
-	  bank0 = 1'h1;
-	  tmp_read_data = mem_read_data0;
-	end
+	case(address[9 : 8])
+	  0: begin
+	    bank0 = 1'h1;
+	    tmp_read_data = mem_read_data0;
+	  end
+
+	  1: begin
+	    bank1 = 1'h1;
+	    tmp_read_data = mem_read_data1;
+	  end
+
+	  2: begin
+	    bank2 = 1'h1;
+	    tmp_read_data = mem_read_data2;
+	  end
+
+	  3: begin
+	    bank3 = 1'h1;
+	    tmp_read_data = mem_read_data3;
+	  end
+
+	  default: begin
+	  end
+	endcase // case (address[9 : 8])
       end
     end
 


### PR DESCRIPTION
## Description
This is a Proof of Concept PR that tries to double the size of the FW_RAM by adding two more banks of instantiated block RAM.

The change allocates 70 LCs for more complex decode logi. And four extra EBRs, as expected.
The big issue is the effect on max clock frequency. From 22.59 MHz in main, to 20.49 MHz for the PoC.

The problem quite probably is due to routing. The EBRs are spread out evenly over the FPGA fabric in the die. We already allocate 70% of all EBRs, and with the PoC, we push this to 80% (24 out of 30). This means that the address bus and the data buses have to stretch long distances (and through several switches). One could try and mitigate this by adding registers at each end of the buses. This would allow for one cycle for transport. The consequence is allocation of more LCs, and that access latency to the FW_RAM would at least double. But we don't execute code from the FW_RAM, so this may be ok.

The PoC doesn't include such an attempt. The description here is just to document the result of the PoC and possible fix of the clock frequency issues.


Fixes # (issues)
A cramped FW_RAM

## Type of change

Please tick any that are relevant to this PR and remove any that aren't.

- [ ] Bugfix (non breaking change which resolve an issue)
- [X] Feature (non breaking change which adds functionality)
- [ ] Breaking Change (a change which would cause existing functionality to not work as expected)
- [ ] Documentation (a change to documentation)

## Submission checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my changes
- [ ] I have tested and verified my changes on target
- [ ] My changes are well written and CI is passing
- [ ] I have squashed my work to relevant commits and rebased on main for linear history
- [ ] I have added a "Co-authored-by: x" if several people contributed, either pair programming or by squashing commits from different authors.
- [ ] I have updated the documentation where relevant (readme, dev.tillitis.se etc.)
- [ ] QEMU is updated to reflect changes
