### PR TITLE
Free running timer

### DIFF
--- a/hw/application_fpga/core/timer/README.md
+++ b/hw/application_fpga/core/timer/README.md
@@ -37,3 +37,6 @@ The following addresses define the API for the timer:
 	FREE_RUNNING_BIT    0
 
 ```
+
+ADDR_PRESCALER and ADDR_TIMER should be set to a non-negative value (default are one.)
+Note that these values can't be changed when the timer is running.

--- a/hw/application_fpga/core/timer/README.md
+++ b/hw/application_fpga/core/timer/README.md
@@ -1,21 +1,20 @@
 # timer
-Timer with prescaler and support for free running mode.
+Timer with prescaler and support for detecting when a target time has
+been reached.w
 
 ## Introduction
-This core implements a simple timer with a prescaler and support for a
-free running mode.
+This core implements a simple timer with a prescaler and ability to
+signal when a given time has been reached.
 
-The prescaler allows measurement of time durations rather than
+The prescaler allows measurement of time duration rather than
 cycles. If for example setting the prescaler to the clock frequency in
-Hertz, the timer will count seconds. After (prescaler * timer) number
-of cycles the timer will stop. Checking status of the timer can be
-done by reading the STATUS_RUNNING_BIT. If set to zero, the timer has
-completed.
+Hertz, the timer will count seconds.
 
-If the free running mode is set (default off), the counter will not
-stpp when the number of cycles defined by (prescaler * timer) has been
-reached. Instead the timer continues until the CTRL_STOP_BIT is
-asserted.
+When started the timer will set the STATUS_RUNNING_BIT. The timer will
+not stop until the CTRL_STOP has been asserted.
+
+When timer has been started, after the set (prescaler * timer) number
+of cycles, the timer will set the STATUS_REACHED bit.
 
 ## API
 The following addresses define the API for the timer:
@@ -27,15 +26,12 @@ The following addresses define the API for the timer:
 
 	ADDR_STATUS:        0x09
 	STATUS_RUNNING_BIT: 0
+	STATUS_REACHED:     1
 
 	ADDR_PRESCALER:     0x0a
 	ADDR_TIMER:         0x0b
-
-	ADDR_FREE_RUNNING:  0x0c
-	FREE_RUNNING_BIT    0
-
 ```
 
 ADDR_PRESCALER and ADDR_TIMER registers should be set to a
-non-negative value. Default values for the these registers are one (1).
+non-zero value. Default values for the these registers are one (1).
 Note that these registers can't be changed when the timer is running.

--- a/hw/application_fpga/core/timer/README.md
+++ b/hw/application_fpga/core/timer/README.md
@@ -13,11 +13,9 @@ done by reading the STATUS_RUNNING_BIT. If set to zero, the timer has
 completed.
 
 If the free running mode is set (default off), the counter will not
-stup when the number of cycles defined by (prescaler * timer) has been
+stpp when the number of cycles defined by (prescaler * timer) has been
 reached. Instead the timer continues until the CTRL_STOP_BIT is
-asserted. Note that in free running mode, the ADDR_PRESCALER shall be
-set to one (1).
-
+asserted.
 
 ## API
 The following addresses define the API for the timer:
@@ -38,5 +36,6 @@ The following addresses define the API for the timer:
 
 ```
 
-ADDR_PRESCALER and ADDR_TIMER should be set to a non-negative value (default are one.)
-Note that these values can't be changed when the timer is running.
+ADDR_PRESCALER and ADDR_TIMER registers should be set to a
+non-negative value. Default values for the these registers are one (1).
+Note that these registers can't be changed when the timer is running.

--- a/hw/application_fpga/core/timer/README.md
+++ b/hw/application_fpga/core/timer/README.md
@@ -1,37 +1,39 @@
 # timer
-A simple timer with prescaler.
+Timer with prescaler and support for free running mode.
 
 ## Introduction
-This core implements a simple timer with a prescaler. The prescaler
-allows measurement of time durations rather than cycles. If for
-example setting the prescaler to the clock frequency in Hertz, the
-timer will count seconds.
+This core implements a simple timer with a prescaler and support for a
+free running mode.
+
+The prescaler allows measurement of time durations rather than
+cycles. If for example setting the prescaler to the clock frequency in
+Hertz, the timer will count seconds. After (prescaler * timer) number
+of cycles the timer will stop. Checking status of the timer can be
+done by reading the STATUS_RUNNING_BIT. If set to zero, the timer has
+completed.
+
+If the free running mode is set (default off), the counter will not
+stup when the number of cycles defined by (prescaler * timer) has been
+reached. Instead the timer continues until the CTRL_STOP_BIT is
+asserted. Note that in free running mode, the ADDR_PRESCALER shall be
+set to one (1).
+
 
 ## API
-
 The following addresses define the API for the timer:
 
 ```
-	ADDR_CTRL: 0x08
-	CTRL_START_BIT: 0
-	CTRL_STOP_BIT:  1
+	ADDR_CTRL:          0x08
+	CTRL_START_BIT:     0
+	CTRL_STOP_BIT:      1
 
-	ADDR_STATUS: 0x09
+	ADDR_STATUS:        0x09
 	STATUS_RUNNING_BIT: 0
 
-	ADDR_PRESCALER: 0x0a
-	ADDR_TIMER:     0x0b
+	ADDR_PRESCALER:     0x0a
+	ADDR_TIMER:         0x0b
+
+	ADDR_FREE_RUNNING:  0x0c
+	FREE_RUNNING_BIT    0
+
 ```
-
-
-## Details
-The core consists of the timer_core module (in timer_core.v) and a top
-level wrapper, timer (in timer.v). The top level wrapper implements
-the API, while the timer_core implements the actual timer
-functionality.
-
-The timer counter and the prescaler counter are both 32 bits.
-When enabled the counter counts down one integer value per cycle.
-
-The timer will stop when reaching final zero (given by prescaler times the initial value of the timer)
-and the running flag will be lowered.

--- a/hw/application_fpga/core/timer/rtl/timer.v
+++ b/hw/application_fpga/core/timer/rtl/timer.v
@@ -106,8 +106,8 @@ module timer(
 	start_reg        <= 1'h0;
 	stop_reg         <= 1'h0;
 	free_running_reg <= 1'h0;
-	prescaler_reg    <= 32'h0;
-	timer_reg        <= 32'h0;
+	prescaler_reg    <= 32'h1;
+	timer_reg        <= 32'h1;
       end
       else begin
 	start_reg <= start_new;

--- a/hw/application_fpga/core/timer/rtl/timer.v
+++ b/hw/application_fpga/core/timer/rtl/timer.v
@@ -103,10 +103,11 @@ module timer(
   always @ (posedge clk)
     begin : reg_update
       if (!reset_n) begin
-	start_reg     <= 1'h0;
-	stop_reg      <= 1'h0;
-	prescaler_reg <= 32'h0;
-	timer_reg     <= 32'h0;
+	start_reg        <= 1'h0;
+	stop_reg         <= 1'h0;
+	free_running_reg <= 1'h0;
+	prescaler_reg    <= 32'h0;
+	timer_reg        <= 32'h0;
       end
       else begin
 	start_reg <= start_new;
@@ -121,7 +122,7 @@ module timer(
 	end
 
 	if (free_running_we) begin
-	  free_running_reg <= write_data[0];
+	  free_running_reg <= write_data[FREE_RUNNING_BIT];
 	end
       end
     end // reg_update

--- a/hw/application_fpga/core/timer/rtl/timer.v
+++ b/hw/application_fpga/core/timer/rtl/timer.v
@@ -30,15 +30,17 @@ module timer(
   //----------------------------------------------------------------
   // Internal constant and parameter definitions.
   //----------------------------------------------------------------
-  localparam ADDR_CTRL          = 8'h08;
-  localparam CTRL_START_BIT     = 0;
-  localparam CTRL_STOP_BIT      = 1;
+  localparam ADDR_CTRL             = 8'h08;
+  localparam CTRL_START_BIT        = 0;
+  localparam CTRL_STOP_BIT         = 1;
 
-  localparam ADDR_STATUS        = 8'h09;
-  localparam STATUS_RUNNING_BIT = 0;
+  localparam ADDR_STATUS           = 8'h09;
+  localparam STATUS_RUNNING_BIT    = 0;
 
-  localparam ADDR_PRESCALER     = 8'h0a;
-  localparam ADDR_TIMER         = 8'h0b;
+  localparam ADDR_PRESCALER        = 8'h0a;
+  localparam ADDR_TIMER            = 8'h0b;
+  localparam ADDR_FREE_RUNNING     = 8'h0c;
+  localparam FREE_RUNNING_BIT      = 0;
 
 
   //----------------------------------------------------------------
@@ -55,6 +57,9 @@ module timer(
 
   reg          stop_reg;
   reg          stop_new;
+
+  reg          free_running_reg;
+  reg          free_running_we;
 
 
   //----------------------------------------------------------------
@@ -85,6 +90,7 @@ module timer(
                   .timer_init(timer_reg),
                   .start(start_reg),
                   .stop(stop_reg),
+		  .free_running(free_running_reg),
 
 		  .curr_timer(core_curr_timer),
                   .running(core_running)
@@ -113,6 +119,10 @@ module timer(
 	if (timer_we) begin
 	  timer_reg <= write_data;
 	end
+
+	if (free_running_we) begin
+	  free_running_reg <= write_data[0];
+	end
       end
     end // reg_update
 
@@ -124,12 +134,13 @@ module timer(
   //----------------------------------------------------------------
   always @*
     begin : api
-      start_new     = 1'h0;
-      stop_new      = 1'h0;
-      prescaler_we  = 1'h0;
-      timer_we      = 1'h0;
-      tmp_read_data = 32'h0;
-      tmp_ready     = 1'h0;
+      start_new       = 1'h0;
+      stop_new        = 1'h0;
+      free_running_we = 1'h0;
+      prescaler_we    = 1'h0;
+      timer_we        = 1'h0;
+      tmp_read_data   = 32'h0;
+      tmp_ready       = 1'h0;
 
       if (cs) begin
 	tmp_ready = 1'h1;
@@ -147,6 +158,10 @@ module timer(
 
             if (address == ADDR_TIMER) begin
 	      timer_we = 1'h1;
+	    end
+
+            if (address == ADDR_FREE_RUNNING) begin
+	      free_running_we = 1'h1;
 	    end
 	  end
         end

--- a/hw/application_fpga/core/timer/rtl/timer_core.v
+++ b/hw/application_fpga/core/timer/rtl/timer_core.v
@@ -31,9 +31,8 @@ module timer_core(
   //----------------------------------------------------------------
   // Internal constant and parameter definitions.
   //----------------------------------------------------------------
-  localparam CTRL_IDLE      = 2'h0;
-  localparam CTRL_PRESCALER = 2'h1;
-  localparam CTRL_TIMER     = 2'h2;
+  localparam CTRL_IDLE    = 1'h0;
+  localparam CTRL_RUNNING = 1'h1;
 
 
   //----------------------------------------------------------------
@@ -55,8 +54,8 @@ module timer_core(
   reg          timer_rst;
   reg          timer_inc;
 
-  reg [1 : 0]  core_ctrl_reg;
-  reg [1 : 0]  core_ctrl_new;
+  reg          core_ctrl_reg;
+  reg          core_ctrl_new;
   reg          core_ctrl_we;
 
 
@@ -160,13 +159,13 @@ module timer_core(
 	    prescaler_rst = 1'h1;
 	    timer_rst     = 1'h1;
 
-	    core_ctrl_new = CTRL_PRESCALER;
+	    core_ctrl_new = CTRL_RUNNING;
 	    core_ctrl_we  = 1'h1;
           end
         end
 
 
-	CTRL_PRESCALER: begin
+	CTRL_RUNNING: begin
 	  if (stop) begin
             running_new   = 1'h0;
             running_we    = 1'h1;

--- a/hw/application_fpga/core/timer/rtl/timer_core.v
+++ b/hw/application_fpga/core/timer/rtl/timer_core.v
@@ -175,36 +175,20 @@ module timer_core(
 	  end
 
 	  else begin
-	    if (prescaler_reg == prescaler_init) begin
-              core_ctrl_new = CTRL_TIMER;
-              core_ctrl_we  = 1'h1;
+	    if (prescaler_reg == (prescaler_init - 1)) begin
+	      if ((timer_reg == (timer_init - 1)) & ~free_running) begin
+		running_new   = 1'h0;
+		running_we    = 1'h1;
+		core_ctrl_new = CTRL_IDLE;
+		core_ctrl_we  = 1'h1;
+	      end
+	      else begin
+		timer_inc     = 1'h1;
+		prescaler_rst = 1'h1;
+	      end
 	    end
 	    else begin
 	      prescaler_inc = 1'h1;
-	    end
-	  end
-	end
-
-
-	CTRL_TIMER: begin
-	  if (stop) begin
-            running_new   = 1'h0;
-            running_we    = 1'h1;
-            core_ctrl_new = CTRL_IDLE;
-            core_ctrl_we  = 1'h1;
-	  end
-	  else begin
-	    if ((timer_reg == timer_init) & ~free_running) begin
-              running_new   = 1'h0;
-              running_we    = 1'h1;
-              core_ctrl_new = CTRL_IDLE;
-              core_ctrl_we  = 1'h1;
-	    end
-	    else begin
-	      timer_inc     = 1'h1;
-	      prescaler_rst = 1'h1;
-	      core_ctrl_new = CTRL_PRESCALER;
-	      core_ctrl_we  = 1'h1;
 	    end
 	  end
 	end

--- a/hw/application_fpga/core/timer/tb/tb_timer.v
+++ b/hw/application_fpga/core/timer/tb/tb_timer.v
@@ -344,10 +344,67 @@ module tb_timer();
 	error_ctr = error_ctr + 1;
       end
 
+      // Stop the timer.
+      write_word(ADDR_CTRL, 32'h2);
+
       $display("--- test2: completed.");
       $display("");
     end
-  endtask // tes1
+  endtask // test2
+
+
+  //----------------------------------------------------------------
+  // test3()
+  //
+  // Set free running mode, set the prescler to two and start the
+  // timer. Wait a numer of cycles and read out the current timer
+  // value. the counter value should be half of the number
+  // of cycles executed.
+  // ----------------------------------------------------------------
+  task test3;
+    begin : test3
+      reg [31 : 0] time_start;
+      reg [31 : 0] time_stop;
+      reg [31 : 0] time_expected;
+      reg [31 : 0] time_counted;
+
+      tc_ctr = tc_ctr + 1;
+      tb_monitor = 0;
+
+      $display("");
+      $display("--- test3: started.");
+      $display("--- test3: Free running counter with prescaler in an expected number of cycles.");
+
+      write_word(ADDR_PRESCALER, 32'h2);
+      write_word(ADDR_TIMER, 32'h9);
+      write_word(ADDR_FREE_RUNNING, 32'h1);
+
+      write_word(ADDR_CTRL, 32'h1);
+      time_start = cycle_ctr;
+
+      $display("--- test3: Waiting 2048 cycles.");
+      #(2048 * CLK_PERIOD);
+      read_word(ADDR_TIMER);
+
+      time_expected = (cycle_ctr - time_start) >> 1;
+      time_counted = tb_read_data;
+
+      if (time_counted == time_expected) begin
+	$display("--- test3: Correct number of cycles counted: %0d", time_counted);
+      end
+      else begin
+	$display("--- test3: Error, expected %0d cycles, counted cycles: %0d",
+		 time_expected, time_counted);
+	error_ctr = error_ctr + 1;
+      end
+
+      // Stop the timer.
+      write_word(ADDR_CTRL, 32'h2);
+
+      $display("--- test3: completed.");
+      $display("");
+    end
+  endtask // test3
 
 
   //----------------------------------------------------------------
@@ -364,6 +421,7 @@ module tb_timer();
       reset_dut();
       test1();
       test2();
+      test3();
 
       display_test_result();
       $display("");

--- a/hw/application_fpga/core/timer/tb/tb_timer.v
+++ b/hw/application_fpga/core/timer/tb/tb_timer.v
@@ -255,7 +255,7 @@ module tb_timer();
   // test1()
   //
   // Set timer and scaler and then start the timer. Wait
-  // for the ready flag to be asserted again.
+  // for the reached flag to be asserted.
   //----------------------------------------------------------------
   task test1;
     begin : test1
@@ -275,12 +275,13 @@ module tb_timer();
       write_word(ADDR_TIMER, 32'h9);
       time_expected = 32'h6 * 32'h9;
 
+      // Start the timer.
       write_word(ADDR_CTRL, 32'h1);
       time_start = cycle_ctr;
 
       #(CLK_PERIOD);
       read_word(ADDR_STATUS);
-      while (read_data) begin
+      while (read_data != 3) begin
 	read_word(ADDR_STATUS);
       end
       time_stop = cycle_ctr;
@@ -296,10 +297,13 @@ module tb_timer();
 	error_ctr = error_ctr + 1;
       end
 
+      // Stop the timer.
+      write_word(ADDR_CTRL, 32'h2);
+
       $display("--- test1: completed.");
       $display("");
     end
-  endtask // tes1
+  endtask // test1
 
 
   //----------------------------------------------------------------
@@ -373,7 +377,7 @@ module tb_timer();
 
       $display("");
       $display("--- test3: started.");
-      $display("--- test3: Free running counter with prescaler in an expected number of cycles.");
+      $display("--- test3: Free running counter with prescaler = 2 in an expected number of cycles.");
 
       write_word(ADDR_PRESCALER, 32'h2);
       write_word(ADDR_TIMER, 32'h9);

--- a/hw/application_fpga/core/timer/tb/tb_timer_core.v
+++ b/hw/application_fpga/core/timer/tb/tb_timer_core.v
@@ -215,6 +215,8 @@ module tb_timer_core();
 
   //----------------------------------------------------------------
   // test1()
+  //
+  // Test that the timer can count to a specified number of cycles.
   //----------------------------------------------------------------
   task test1;
     begin : test1
@@ -225,7 +227,7 @@ module tb_timer_core();
       tc_ctr = tc_ctr + 1;
 
       $display("--- test1: Run timer to set value started.");
-      $display("--- test1: prescaler: 6, timer: 9. Should take 6*9 + 1 = 55 cycles..");
+      $display("--- test1: prescaler: 6, timer: 9. Should take 6*9 + 1 = 55 cycles.");
       tb_prescaler_init = 32'h6;
       tb_timer_init     = 32'h9;
       test1_expected_num_cycles = tb_prescaler_init * tb_timer_init + 1;

--- a/hw/application_fpga/core/timer/tb/tb_timer_core.v
+++ b/hw/application_fpga/core/timer/tb/tb_timer_core.v
@@ -39,8 +39,8 @@ module tb_timer_core();
   reg  [31 : 0] tb_timer_init;
   reg           tb_start;
   reg           tb_stop;
-  reg           tb_free_running;
   wire [31 : 0] tb_curr_timer;
+  wire          tb_reached;
   wire          tb_running;
 
 
@@ -54,8 +54,8 @@ module tb_timer_core();
 		 .timer_init(tb_timer_init),
 		 .start(tb_start),
 		 .stop(tb_stop),
-		 .free_running(tb_free_running),
 		 .curr_timer(tb_curr_timer),
+		 .reached(tb_reached),
 		 .running(tb_running)
                 );
 
@@ -103,8 +103,8 @@ module tb_timer_core();
       $display("Inputs and outputs:");
       $display("prescaler_init: 0x%08x, timer_init: 0x%08x",
 	       dut.prescaler_init, dut.timer_init);
-      $display("start: 0x%1x, stop: 0x%1x, running: 0x%1x",
-	       dut.start, dut.stop, dut.running);
+      $display("start: 0x%1x, stop: 0x%1x, reached: 0x%1x,  running: 0x%1x",
+	       dut.start, dut.stop, dut.reached);
       $display("");
       $display("Internal state:");
       $display("prescaler_reg: 0x%08x, prescaler_new: 0x%08x",
@@ -206,7 +206,6 @@ module tb_timer_core();
 
       tb_start          = 1'h0;
       tb_stop           = 1'h0;
-      tb_free_running   = 1'h0;
       tb_prescaler_init = 32'h0;
       tb_timer_init     = 32'h0;
     end
@@ -239,7 +238,7 @@ module tb_timer_core();
       tb_start = 1'h0;
       #(CLK_PERIOD);
 
-      while (tb_running) begin
+      while (~tb_reached) begin
 	#(CLK_PERIOD);
       end
       test1_counted_num_cycles = cycle_ctr - test1_cycle_ctr_start;
@@ -253,6 +252,10 @@ module tb_timer_core();
 		 test1_expected_num_cycles, test1_counted_num_cycles);
 	error_ctr = error_ctr + 1;
       end
+
+      tb_stop = 1'h1;
+      #(CLK_PERIOD);
+      tb_stop = 1'h0;
 
       $display("--- test1: Completed.");
       $display("");
@@ -279,7 +282,6 @@ module tb_timer_core();
 
       tb_prescaler_init     = 32'h1;
       tb_timer_init         = 32'h1;
-      tb_free_running       = 1'h1;
       tb_start              = 1'h1;
       test1_cycle_ctr_start = cycle_ctr;
 

--- a/hw/application_fpga/core/timer/tb/tb_timer_core.v
+++ b/hw/application_fpga/core/timer/tb/tb_timer_core.v
@@ -39,6 +39,7 @@ module tb_timer_core();
   reg  [31 : 0] tb_timer_init;
   reg           tb_start;
   reg           tb_stop;
+  reg           tb_free_running;
   wire [31 : 0] tb_curr_timer;
   wire          tb_running;
 
@@ -53,6 +54,7 @@ module tb_timer_core();
 		 .timer_init(tb_timer_init),
 		 .start(tb_start),
 		 .stop(tb_stop),
+		 .free_running(tb_free_running),
 		 .curr_timer(tb_curr_timer),
 		 .running(tb_running)
                 );
@@ -107,13 +109,13 @@ module tb_timer_core();
       $display("Internal state:");
       $display("prescaler_reg: 0x%08x, prescaler_new: 0x%08x",
 	       dut.prescaler_reg, dut.prescaler_new);
-      $display("prescaler_set: 0x%1x, prescaler_dec: 0x%1x",
-	       dut.prescaler_set, dut.prescaler_dec);
+      $display("prescaler_rst: 0x%1x, prescaler_inc: 0x%1x",
+	       dut.prescaler_rst, dut.prescaler_inc);
       $display("");
       $display("timer_reg: 0x%08x, timer_new: 0x%08x",
 	       dut.timer_reg, dut.timer_new);
-      $display("timer_set: 0x%1x, timer_dec: 0x%1x",
-	       dut.timer_set, dut.timer_dec);
+      $display("timer_rst: 0x%1x, timer_inc: 0x%1x",
+	       dut.timer_rst, dut.timer_inc);
       $display("");
       $display("core_ctrl_reg: 0x%02x, core_ctrl_new: 0x%02x, core_ctrl_we: 0x%1x",
 	       dut.core_ctrl_reg, dut.core_ctrl_new, dut.core_ctrl_we);
@@ -184,6 +186,7 @@ module tb_timer_core();
 
       tb_start          = 1'h0;
       tb_stop           = 1'h0;
+      tb_free_running   = 1'h0;
       tb_prescaler_init = 32'h0;
       tb_timer_init     = 32'h0;
     end

--- a/hw/application_fpga/core/timer/tb/tb_timer_core.v
+++ b/hw/application_fpga/core/timer/tb/tb_timer_core.v
@@ -246,7 +246,7 @@ module tb_timer_core();
 
 
       if (test1_counted_num_cycles == test1_expected_num_cycles) begin
-	$display("--- test1: Corrcet number of cycles counted: %0d", test1_counted_num_cycles);
+	$display("--- test1: Correct number of cycles counted: %0d", test1_counted_num_cycles);
       end
       else begin
 	$display("--- test1: Error, expected %0d cycles, counted cycles: %0d",
@@ -258,6 +258,51 @@ module tb_timer_core();
       $display("");
     end
   endtask // test1
+
+
+
+  //----------------------------------------------------------------
+  // test2()
+  //
+  // Test that the free running functionality works.
+  //----------------------------------------------------------------
+  task test2;
+    begin : test2
+      reg [31 : 0] test1_cycle_ctr_start;
+      reg [31 : 0] test1_counted_num_cycles;
+      reg [31 : 0] test1_expected_num_cycles;
+
+      tc_ctr = tc_ctr + 1;
+
+      $display("--- test2: Run timer in free running mode started.");
+      $display("--- test2: Set prescaler and timer to one, but wait more cycles.");
+
+      tb_prescaler_init     = 32'h1;
+      tb_timer_init         = 32'h1;
+      tb_free_running       = 1'h1;
+      tb_start              = 1'h1;
+      test1_cycle_ctr_start = cycle_ctr;
+
+      #(CLK_PERIOD);
+      tb_start = 1'h0;
+      test1_cycle_ctr_start = cycle_ctr;
+
+      #(1337 * CLK_PERIOD);
+      test1_expected_num_cycles = cycle_ctr - test1_cycle_ctr_start;
+
+      if (tb_curr_timer == test1_expected_num_cycles) begin
+	$display("--- test2: Correct number of cycles counted: %0d", tb_curr_timer);
+      end
+      else begin
+	$display("--- test2: Error, expected %0d cycles, counted cycles: %0d",
+		 test1_expected_num_cycles, tb_curr_timer);
+	error_ctr = error_ctr + 1;
+      end
+
+      $display("--- test2: Completed.");
+      $display("");
+    end
+  endtask // test2
 
 
   //----------------------------------------------------------------
@@ -274,6 +319,7 @@ module tb_timer_core();
       reset_dut();
 
       test1();
+      test2();
 
       display_test_result();
       $display("");


### PR DESCRIPTION
## Description

This PR implements a change to the existing timer to add a free running mode. This is currently an initial version. The testbenches has not been updated with tests of the new mode. But it builds and allow us to measure the amount of resources the changes cause.

Note that this PR breaks the behavior of the timer. Previously both the timer and the prescaler would count down from a set value. The PR changes this so that now the timer and prescaler starts at zero and counts up to the set values. Applications that look at the timer current_value will probably be confused. Applications that just sets the timer and wait for it to complete (stop running) will not be affected.

Fixes #252 

## Type of change

Please tick any that are relevant to this PR and remove any that aren't.

- [ ] Bugfix (non breaking change which resolve an issue)
- [ ] Feature (non breaking change which adds functionality)
- [X] Breaking Change (a change which would cause existing functionality to not work as expected)
- [ ] Documentation (a change to documentation)

## Submission checklist

- [X] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my changes
- [ ] I have tested and verified my changes on target
- [ ] My changes are well written and CI is passing
- [ ] I have squashed my work to relevant commits and rebased on main for linear history
- [ ] I have added a "Co-authored-by: x" if several people contributed, either pair programming or by squashing commits from different authors.
- [ ] I have updated the documentation where relevant (readme, dev.tillitis.se etc.)
- [ ] QEMU is updated to reflect changes
