### PR TITLE
Syscall poc

### DIFF
--- a/hw/application_fpga/core/tk1/rtl/tk1.v
+++ b/hw/application_fpga/core/tk1/rtl/tk1.v
@@ -26,6 +26,9 @@ module tk1(
 	   output wire          force_trap,
 	   output               system_reset,
 
+	   output wire [31 : 0] syscall_addr,
+	   output wire          syscall,
+
 	   output wire [14 : 0] ram_addr_rand,
 	   output wire [31 : 0] ram_data_rand,
 
@@ -80,6 +83,9 @@ module tk1(
   localparam ADDR_APP_SIZE      = 8'h0d;
 
   localparam ADDR_BLAKE2S       = 8'h10;
+
+  localparam ADDR_SYSCALL_ADDR  = 8'h12;
+  localparam ADDR_SYSCALL_START = 8'h13;
 
   localparam ADDR_CDI_FIRST     = 8'h20;
   localparam ADDR_CDI_LAST      = 8'h27;
@@ -138,6 +144,9 @@ module tk1(
   reg [31 : 0] blake2s_addr_reg;
   reg          blake2s_addr_we;
 
+  reg [31 : 0] syscall_addr_reg;
+  reg          syscall_addr_we;
+
   reg [23 : 0] cpu_trap_ctr_reg;
   reg [23 : 0] cpu_trap_ctr_new;
   reg [2 : 0]  cpu_trap_led_reg;
@@ -175,6 +184,8 @@ module tk1(
 
   wire [31:0]  udi_rdata;
 
+  reg          start_syscall;
+
 `ifdef INCLUDE_SPI_MASTER
   reg          spi_enable;
   reg          spi_enable_vld;
@@ -203,6 +214,9 @@ module tk1(
   assign ram_data_rand = ram_data_rand_reg;
 
   assign system_reset = system_reset_reg;
+
+  assign syscall_addr = syscall_addr_reg;
+  assign syscall      = start_syscall;
 
 
   //----------------------------------------------------------------
@@ -268,6 +282,7 @@ module tk1(
         app_start_reg     <= 32'h0;
         app_size_reg      <= 32'h0;
         blake2s_addr_reg  <= 32'h0;
+        syscall_addr_reg  <= 32'h0;
 	cdi_mem[0]        <= 32'h0;
 	cdi_mem[1]        <= 32'h0;
 	cdi_mem[2]        <= 32'h0;
@@ -324,6 +339,10 @@ module tk1(
 
         if (blake2s_addr_we) begin
           blake2s_addr_reg <= write_data;
+        end
+
+        if (syscall_addr_we) begin
+          syscall_addr_reg <= write_data;
         end
 
 	if (cdi_mem_we) begin
@@ -436,6 +455,8 @@ module tk1(
       app_start_we     = 1'h0;
       app_size_we      = 1'h0;
       blake2s_addr_we  = 1'h0;
+      syscall_addr_we  = 1'h0;
+      start_syscall    = 1'h0;
       cdi_mem_we       = 1'h0;
       cdi_mem_we       = 1'h0;
       ram_addr_rand_we = 1'h0;
@@ -493,6 +514,16 @@ module tk1(
 	    if (!switch_app_reg) begin
               blake2s_addr_we = 1'h1;
             end
+	  end
+
+          if (address == ADDR_SYSCALL_ADDR) begin
+	    if (!switch_app_reg) begin
+              syscall_addr_we = 1'h1;
+            end
+	  end
+
+          if (address == ADDR_SYSCALL_START) begin
+            start_syscall = 1'h1;
 	  end
 
 	  if ((address >= ADDR_CDI_FIRST) && (address <= ADDR_CDI_LAST)) begin

--- a/hw/application_fpga/rtl/application_fpga.v
+++ b/hw/application_fpga/rtl/application_fpga.v
@@ -149,6 +149,8 @@ module application_fpga(
   wire [14 : 0] ram_addr_rand;
   wire [31 : 0] ram_data_rand;
   wire          tk1_system_reset;
+  wire [31 : 0] tk1_syscall_addr;
+  wire          tk1_syscall;
   /* verilator lint_on UNOPTFLAT */
 
 
@@ -328,6 +330,9 @@ module application_fpga(
 
 	       .system_reset(tk1_system_reset),
 
+	       .syscall_addr(tk1_syscall_addr),
+	       .syscall(tk1_syscall),
+
                .ram_addr_rand(ram_addr_rand),
 	       .ram_data_rand(ram_data_rand),
 
@@ -443,10 +448,16 @@ module application_fpga(
             end
 
             RAM_PREFIX: begin
-	      ram_cs          = 1'h1;
-	      ram_we          = cpu_wstrb;
-	      muxed_rdata_new = ram_read_data ^ ram_data_rand ^ {2{cpu_addr[15 : 0]}};
-	      muxed_ready_new = ram_ready;
+	      if (tk1_syscall) begin
+		muxed_rdata_new = tk1_syscall_addr;
+		muxed_ready_new = 1'h1;
+	      end
+	      else begin
+		ram_cs          = 1'h1;
+		ram_we          = cpu_wstrb;
+		muxed_rdata_new = ram_read_data ^ ram_data_rand ^ {2{cpu_addr[15 : 0]}};
+		muxed_ready_new = ram_ready;
+	      end
 	    end
 
             RESERVED_PREFIX: begin


### PR DESCRIPTION
## Description
This PR implements a PoC for a syscall, trap function.
The FW can write a jump instruction (with a target address) into an ADDR_SYSCALL_INSTR API address in tk1. The device app (and FW) can write to ADDR_SYSCALL_START API address in tk1. When written to the CPU will be forced to use the jump address in ADDR_SYSCALL_INSTR as next instruction to execute.

This could, may work. One issue may be timing (as in clock cycles). The ADDR_SYSCALL_START  trigger must be set at the right cycle in relation to the CPU reading the next instruction. If it's one cycle too early or too late it will probably crash.

One could also simply force the CPU to use another address (not a specific instruction). But at least during PoC hack, trying to do so made the synthesis tool Yosys to allocate a design 180% of the available resources.


Fixes # (issues)
None

## Type of change
Feature PoC

Please tick any that are relevant to this PR and remove any that aren't.

- [ ] Bugfix (non breaking change which resolve an issue)
- [X] Feature (non breaking change which adds functionality)
- [ ] Breaking Change (a change which would cause existing functionality to not work as expected)
- [ ] Documentation (a change to documentation)

## Submission checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my changes
- [ ] I have tested and verified my changes on target
- [ ] My changes are well written and CI is passing
- [ ] I have squashed my work to relevant commits and rebased on main for linear history
- [ ] I have added a "Co-authored-by: x" if several people contributed, either pair programming or by squashing commits from different authors.
- [ ] I have updated the documentation where relevant (readme, dev.tillitis.se etc.)
- [ ] QEMU is updated to reflect changes
