### PR TITLE
Include SPI master in default build

### DIFF
--- a/contrib/Makefile
+++ b/contrib/Makefile
@@ -33,11 +33,6 @@ run-make:
 	podman run --rm --mount type=bind,source="`pwd`/../hw/application_fpga",target=/build -w /build -it \
 	 $(IMAGE) make clean application_fpga.bin
 
-run-make-spi:
-	podman run --rm --mount type=bind,source="`pwd`/../hw/application_fpga",target=/build -w /build -it \
-	 $(IMAGE) make clean application_fpga.bin YOSYS_FLAG=-DINCLUDE_SPI_MASTER
-
-
 run-tb:
 	podman run --rm --mount type=bind,source="`pwd`/../hw/application_fpga",target=/build -w /build -it \
 	 $(IMAGE) make clean_tb tb

--- a/hw/application_fpga/Makefile
+++ b/hw/application_fpga/Makefile
@@ -292,13 +292,6 @@ tb:
 #-------------------------------------------------------------------
 # Main FPGA build flow.
 # Synthesis. Place & Route. Bitstream generation.
-#
-# To include the SPI-master, add the flag -DINCLUDE_SPI_MASTER to Yosys cmd.
-# This can, for example, be done using
-# 'make application_fpga.bin YOSYS_FLAG=-DINCLUDE_SPI_MASTER'.
-# Important: do a make clean between builds with and wihtout the SPI master.
-# Otherwise, there is a risk of unintended components persisting between
-# builds.
 #-------------------------------------------------------------------
 
 YOSYS_FLAG ?=

--- a/hw/application_fpga/application_fpga.bin.sha256
+++ b/hw/application_fpga/application_fpga.bin.sha256
@@ -1,1 +1,1 @@
-deb4c6f80b28d12ecfb350ac749369c875866d6715c2d14b1ce1b80a272f3ee6  application_fpga.bin
+8dcd61bda632cee5a11c2eb1fc2b36f4948a9ef872e5826b23cc147c8bd2c975  application_fpga.bin

--- a/hw/application_fpga/core/tk1/rtl/tk1.v
+++ b/hw/application_fpga/core/tk1/rtl/tk1.v
@@ -29,12 +29,10 @@ module tk1(
 	   output wire [14 : 0] ram_addr_rand,
 	   output wire [31 : 0] ram_data_rand,
 
-`ifdef INCLUDE_SPI_MASTER
 	   output wire          spi_ss,
 	   output wire          spi_sck,
 	   output wire          spi_mosi,
 	   input wire           spi_miso,
-`endif // INCLUDE_SPI_MASTER
 
            output wire          led_r,
            output wire          led_g,
@@ -96,11 +94,9 @@ module tk1(
 
   localparam ADDR_SYSTEM_RESET  = 8'h70;
 
-`ifdef INCLUDE_SPI_MASTER
   localparam ADDR_SPI_EN        = 8'h80;
   localparam ADDR_SPI_XFER      = 8'h81;
   localparam ADDR_SPI_DATA      = 8'h82;
-`endif // INCLUDE_SPI_MASTER
 
   localparam TK1_NAME0    = 32'h746B3120; // "tk1 "
   localparam TK1_NAME1    = 32'h6d6b6466; // "mkdf"
@@ -175,7 +171,6 @@ module tk1(
 
   wire [31:0]  udi_rdata;
 
-`ifdef INCLUDE_SPI_MASTER
   reg          spi_enable;
   reg          spi_enable_vld;
   reg          spi_start;
@@ -183,8 +178,6 @@ module tk1(
   reg          spi_tx_data_vld;
   wire         spi_ready;
   wire [7 : 0] spi_rx_data;
-`endif // INCLUDE_SPI_MASTER
-
 
   //----------------------------------------------------------------
   // Concurrent connectivity for ports etc.
@@ -226,7 +219,6 @@ module tk1(
     );
   /* verilator lint_on PINMISSING */
 
-`ifdef INCLUDE_SPI_MASTER
   tk1_spi_master spi_master(
 			    .clk(clk),
 			    .reset_n(reset_n),
@@ -244,8 +236,6 @@ module tk1(
 			    .spi_rx_data(spi_rx_data),
 			    .spi_ready(spi_ready)
 			    );
-`endif // INCLUDE_SPI_MASTER
-
 
     udi_rom rom_i(
 		  .addr(address[0]),
@@ -448,14 +438,12 @@ module tk1(
       tmp_read_data    = 32'h0;
       tmp_ready        = 1'h0;
 
-`ifdef INCLUDE_SPI_MASTER
       spi_enable_vld   = 1'h0;
       spi_start        = 1'h0;
       spi_tx_data_vld  = 1'h0;
 
       spi_enable       = write_data[0];
       spi_tx_data      = write_data[7 : 0];
-`endif // INCLUDE_SPI_MASTER
 
       if (cs) begin
 	tmp_ready = 1'h1;
@@ -529,7 +517,6 @@ module tk1(
 	    end
 	  end
 
-`ifdef INCLUDE_SPI_MASTER
 	  if (address == ADDR_SPI_EN) begin
 	    spi_enable_vld = 1'h1;
 	  end
@@ -541,7 +528,6 @@ module tk1(
 	  if (address == ADDR_SPI_DATA) begin
 	    spi_tx_data_vld = 1'h1;
 	  end
-`endif // INCLUDE_SPI_MASTER
 
 	end
         else begin
@@ -592,7 +578,6 @@ module tk1(
 	    end
 	  end
 
-`ifdef INCLUDE_SPI_MASTER
 	  if (address == ADDR_SPI_XFER) begin
 	    tmp_read_data[0] = spi_ready;
 	  end
@@ -600,7 +585,6 @@ module tk1(
 	  if (address == ADDR_SPI_DATA) begin
 	    tmp_read_data[7 : 0] = spi_rx_data;
 	  end
-`endif // INCLUDE_SPI_MASTER
 
         end
       end

--- a/hw/application_fpga/core/tk1/toolruns/Makefile
+++ b/hw/application_fpga/core/tk1/toolruns/Makefile
@@ -38,7 +38,7 @@ spi.sim: $(TB_SPI_SRC) $(SPI_SRC) $(MEM_MODEL_SRC)
 
 
 top.sim: $(TB_TOP_SRC) $(TOP_SRC)
-	$(CC) $(CC_FLAGS) -o top.sim $^ -DUDI_HEX=\"../tb/udi.hex\" -DINCLUDE_SPI_MASTER
+	$(CC) $(CC_FLAGS) -o top.sim $^ -DUDI_HEX=\"../tb/udi.hex\"
 
 
 sim-spi: spi.sim
@@ -50,7 +50,7 @@ sim-top: top.sim
 
 
 lint-top:  $(LINT_SRC)
-	$(LINT) $(LINT_FLAGS) $^ -DUDI_HEX=\"../tb/udi.hex\" -DINCLUDE_SPI_MASTER
+	$(LINT) $(LINT_FLAGS) $^ -DUDI_HEX=\"../tb/udi.hex\"
 
 
 clean:

--- a/hw/application_fpga/rtl/application_fpga.v
+++ b/hw/application_fpga/rtl/application_fpga.v
@@ -20,12 +20,10 @@ module application_fpga(
                         output wire interface_rx,
                         input wire  interface_tx,
 
-`ifdef INCLUDE_SPI_MASTER
 			output wire spi_ss,
 			output wire spi_sck,
 			output wire spi_mosi,
 			input wire  spi_miso,
-`endif // INCLUDE_SPI_MASTER
 
 			input wire  touch_event,
 
@@ -334,12 +332,10 @@ module application_fpga(
                .ram_addr_rand(ram_addr_rand),
 	       .ram_data_rand(ram_data_rand),
 
-`ifdef INCLUDE_SPI_MASTER
 	       .spi_ss(spi_ss),
 	       .spi_sck(spi_sck),
 	       .spi_mosi(spi_mosi),
 	       .spi_miso(spi_miso),
-`endif // INCLUDE_SPI_MASTER
 
                .led_r(led_r),
                .led_g(led_g),


### PR DESCRIPTION
## Description

Suggestion: Always include SPI master in build.

Pro:

- It's easy to miss to include the SPI master. 
- There are a lot of ugly ifdefs in the design.

Con:
 
- We may want to keep it possible to build without SPI and flash access for future releases of Bellatrix-compatible versions. One suggestion, however, is to support that through software with something in the flash saying that flash isn't available and then turning off the future flash code in the firmware.

## Type of change

- [X] Feature (non breaking change which adds functionality)

## Submission checklist

- [ ] My code follows the style guidelines of this project
- [X] I have performed a self-review of my changes
- [ ] I have tested and verified my changes on target
- [x] My changes are well written and CI is passing
- [ ] I have squashed my work to relevant commits and rebased on main for linear history
- [ ] I have added a "Co-authored-by: x" if several people contributed, either pair programming or by squashing commits from different authors.
- [ ] I have updated the documentation where relevant (readme, dev.tillitis.se etc.)
- [ ] QEMU is updated to reflect changes
