### PR TITLE
Fix flash target in contrib/Makefile

### DIFF
--- a/contrib/Makefile
+++ b/contrib/Makefile
@@ -53,7 +53,7 @@ flash:
 	podman run --rm \
 	--device /dev/bus/usb/$(lsusb | grep -m 1 1209:8886 | awk '{ printf "%s/%s", $2, substr($4,1,3) }') \
 	--mount type=bind,source="`pwd`/../hw/application_fpga",target=/build \
-	-w /build/hw/application_fpga \
+	-w /build \
 	-it $(IMAGE) tillitis-iceprog /build/application_fpga.bin
 
 


### PR DESCRIPTION
## Description

Fixes an issue with running `make -C contrib flash`  (Command found in the [dev guide](https://dev.tillitis.se/unlocked/spiflash/#2-program-spi-flash)). The command exits with the following error: 
`Error: workdir "/build/hw/application_fpga" does not exist on container`

Fixed by setting the working directory to /build.

Previously the working directory was set to `/build/hw/application_fpga`. But that path does not exist since `hw/application_fpga` is already mounted to `/build`. Thus resulting in an error.

## Type of change

- [x] Bugfix (non breaking change which resolve an issue)

## Submission checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my changes
- [x] I have tested and verified my changes on target
- [x] My changes are well written and CI is passing
- [x] I have squashed my work to relevant commits and rebased on main for linear history
