### PR TITLE
Update toolchain with new versions of FPGA tools and remove fw/apps/programmer toolschains

### DIFF
--- a/contrib/Dockerfile
+++ b/contrib/Dockerfile
@@ -1,8 +1,10 @@
-FROM docker.io/library/ubuntu:23.10 as base
+FROM docker.io/library/ubuntu:24.04 as base
 
 RUN apt-get -qq update -y \
     && DEBIAN_FRONTEND=noninteractive \
        apt-get install -y --no-install-recommends \
+               autoconf \
+               bash-completion \
                bison \
                build-essential \
                ca-certificates \
@@ -11,53 +13,67 @@ RUN apt-get -qq update -y \
                clang-tidy \
                cmake \
                flex \
+               g++ \
                gawk \
+               gcc \
                git \
-               golang \
+               gperf \
                graphviz \
-               iverilog \
+               help2man \
                less \
                libboost-dev \
                libboost-filesystem-dev \
                libboost-iostreams-dev \
                libboost-program-options-dev \
+               libboost-python-dev \
+               libboost-system-dev \
                libboost-thread-dev \
                libeigen3-dev \
                libffi-dev \
+               libfl-dev \
                libftdi-dev \
-               libglib2.0-dev \
+               libpython3-dev \
                libusb-1.0-0-dev \
-               libpixman-1-dev \
                libreadline-dev \
                lld \
                llvm \
-               mercurial \
+               make \
                nano \
-               ninja-build \
+               ncdu \
+               perl \
                pkg-config \
+               psmisc \
+               python-is-python3 \
                python3 \
+               python3-full \
                python3-dev \
-               tcl-dev \
-               verilator \
-               vim \
-               xdot \
+               python3-pip \
+               python3-pytest \
                sdcc \
                splint \
-               cmake \
-               gcc-arm-none-eabi \
-               libnewlib-arm-none-eabi \
-               libstdc++-arm-none-eabi-newlib \
+               tcl-dev \
+               vim \
+               xdot \
+               zlib1g-dev \
     && rm -rf /var/lib/apt/lists/*
 
+# Enable bash completion
+RUN sed -i '/#if ! shopt -oq posix; then/ s/^#//' /etc/bash.bashrc
+RUN sed -i '/#  if \[ -f \/usr\/share\/bash-completion\/bash_completion \]; then/ s/^#//' /etc/bash.bashrc
+RUN sed -i '/#    . \/usr\/share\/bash-completion\/bash_completion/ s/^#//' /etc/bash.bashrc
+RUN sed -i '/#  elif \[ -f \/etc\/bash_completion \]; then/ s/^#//' /etc/bash.bashrc
+RUN sed -i '/#    . \/etc\/bash_completion/ s/^#//' /etc/bash.bashrc
+RUN sed -i '/#  fi/ s/^#//' /etc/bash.bashrc
+RUN sed -i '/#fi/ s/^#//' /etc/bash.bashrc
 
 FROM base as toolsbuilder
 
-RUN git clone https://github.com/YosysHQ/icestorm /src
+RUN git clone --depth=1 https://github.com/YosysHQ/icestorm /src
 WORKDIR /src
-RUN git checkout d20a5e9001f46262bf0cef220f1a6943946e421d \
+RUN git checkout 738af822905fdcf0466e9dd784b9ae4b0b34987f \
     && make -j$(nproc --ignore=2) \
     && make install
-RUN git >/usr/local/repo-commit-icestorm describe --all --always --long --dirty
+RUN git describe --all --always --long --dirty > /usr/local/repo-commit-icestorm
 WORKDIR /
 RUN rm -rf /src
 
@@ -66,34 +82,69 @@ RUN git clone -b interfaces --depth=1 https://github.com/tillitis/icestorm /src
 WORKDIR /src/iceprog
 RUN make -j$(nproc --ignore=2) \
     && make PROGRAM_PREFIX=tillitis- install
-RUN git >/usr/local/repo-commit-tillitis--icestorm describe --all --always --long --dirty
+RUN git describe --all --always --long --dirty > /usr/local/repo-commit-tillitis--icestorm
 WORKDIR /
 RUN rm -rf /src
 
-RUN git clone -b yosys-0.36 --depth=1 https://github.com/YosysHQ/yosys /src
+RUN git clone -b 0.45 --depth=1 https://github.com/YosysHQ/yosys /src
 WORKDIR /src
-RUN make -j$(nproc --ignore=2) \
-    && make install
-RUN git >/usr/local/repo-commit-yosys describe --all --always --long --dirty
-WORKDIR /
-RUN rm -rf /src
-
-RUN git clone -b nextpnr-0.6 --depth=1 https://github.com/YosysHQ/nextpnr /src
-WORKDIR /src
-RUN cmake -DARCH=ice40 -DCMAKE_INSTALL_PREFIX=/usr/local . \
+RUN git submodule update --init \
     && make -j$(nproc --ignore=2) \
     && make install
-RUN git >/usr/local/repo-commit-nextpnr describe --all --always --long --dirty
+RUN git describe --all --always --long --dirty > /usr/local/repo-commit-yosys
 WORKDIR /
 RUN rm -rf /src
 
-RUN git clone --branch 1.5.1 --depth 1 https://github.com/raspberrypi/pico-sdk.git /usr/local/pico-sdk
-WORKDIR /usr/local/pico-sdk
-RUN git submodule update --init
-RUN git >/usr/local/repo-commit-picosdk describe --all --always --long --dirty
+RUN git clone -b nextpnr-0.7 https://github.com/YosysHQ/nextpnr /src
+WORKDIR /src
+# Add "Fix handling of RNG seed" #1369
+RUN git cherry-pick --no-commit 6ca64526bb18ace8690872b09ca1251567c116de
+# Add early exit if place fails on timing
+RUN sed -i 's/if (do_route) {/if (do_route \&\& !had_nonfatal_error) {/' common/kernel/command.cc
+RUN sed -i 's/bool warn_on_failure = false/bool warn_on_failure = true/' common/kernel/timing.h
+RUN cmake -DARCH=ice40 . \
+    && make -j$(nproc --ignore=2) \
+    && make install
+RUN git describe --all --always --long --dirty > /usr/local/repo-commit-nextpnr
 WORKDIR /
+RUN rm -rf /src
 
+RUN git clone -b v12_0 --depth=1 https://github.com/steveicarus/iverilog /src
+WORKDIR /src
+RUN sh autoconf.sh \
+    && ./configure \
+    && make -j$(nproc --ignore=2) \
+    && make install
+RUN git describe --all --always --long --dirty > /usr/local/repo-commit-iverilog
+WORKDIR /
+RUN rm -rf /src
+
+RUN git clone -b v5.028 --depth=1 https://github.com/verilator/verilator /src
+WORKDIR /src
+RUN autoconf \
+    && ./configure \
+    && make -j$(nproc --ignore=2) \
+    && make test \
+    && make install
+RUN git describe --all --always --long --dirty > /usr/local/repo-commit-verilator
+WORKDIR /
+RUN rm -rf /src
+
+ADD https://github.com/chipsalliance/verible/releases/download/v0.0-3795-gf4d72375/verible-v0.0-3795-gf4d72375-linux-static-x86_64.tar.gz /src/verible.tar.gz
+WORKDIR /src
+RUN tar xvf verible.tar.gz
+RUN mv -v verible*/bin/* /usr/local/bin
+RUN verible-verilog-format --version | head -1 > /usr/local/repo-commit-verible
+WORKDIR /
+RUN rm -rf /src
+
+RUN git clone -b v1.9.1 https://github.com/cocotb/cocotb.git /src
+WORKDIR /src
+RUN pip install . --break-system-packages
+RUN git describe --all --always --long --dirty > /usr/local/repo-commit-cocotb
+WORKDIR /
+RUN rm -rf /src
 
 FROM base
-LABEL org.opencontainers.image.description="Toolchain for building TKey FPGA bitstream, firmware, apps, programmer firmware"
+LABEL org.opencontainers.image.description="Toolchain for building TKey FPGA bitstream"
 COPY --from=toolsbuilder /usr/local/ /usr/local


### PR DESCRIPTION
## Description

     - Change docker image to ubuntu 24.04
    
     - Add new versions of:
            * clang (18.1.3, part of ubuntu 24.04)
            * icestorm (commit 738af822905fdcf0466e9dd784b9ae4b0b34987f)
            * yosys (0.45)
            * nextpnr (0.7) + extra patches for RNG seed handling and early exit
            * iverilog (v12)
            * verilator (v5.028)
            * verible (v0.0-3795)
            * cocotb (v1.9.1)

     - Remove:
            * gcc-arm-none-eabi
            * libnewlib-arm-none-eabi
            * libstdc++-arm-none-eabi-newlib
            * splint
            * pico-sdk
            * golang
    
    Add lint flag needed for new Verilator version.

## Type of change

Please tick any that are relevant to this PR and remove any that aren't.

- [ ] Bugfix (non breaking change which resolve an issue)
- [ ] Feature (non breaking change which adds functionality)
- [X] Breaking Change (a change which would cause existing functionality to not work as expected)
- [ ] Documentation (a change to documentation)

## Submission checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my changes
- [ ] I have tested and verified my changes on target
- [ ] My changes are well written and CI is passing
- [ ] I have squashed my work to relevant commits and rebased on main for linear history
- [ ] I have added a "Co-authored-by: x" if several people contributed, either pair programming or by squashing commits from different authors.
- [ ] I have updated the documentation where relevant (readme, dev.tillitis.se etc.)
