### PR TITLE
fw: Fix erroneous type in frame header

### DIFF
--- a/hw/application_fpga/fw/tk1/proto.c
+++ b/hw/application_fpga/fw/tk1/proto.c
@@ -23,7 +23,7 @@ static uint8_t genhdr(uint8_t id, uint8_t endpoint, uint8_t status,
 static int parseframe(uint8_t b, struct frame_header *hdr);
 static void write(uint8_t *buf, size_t nbytes);
 static int read(uint8_t *buf, size_t bufsize, size_t nbytes);
-static int bytelen(enum cmdlen cmdlen);
+static size_t bytelen(enum cmdlen cmdlen);
 
 static uint8_t genhdr(uint8_t id, uint8_t endpoint, uint8_t status,
 		      enum cmdlen len)
@@ -165,7 +165,7 @@ static int read(uint8_t *buf, size_t bufsize, size_t nbytes)
 }
 
 // bytelen returns the number of bytes a cmdlen takes
-static int bytelen(enum cmdlen cmdlen)
+static size_t bytelen(enum cmdlen cmdlen)
 {
 	int len = 0;
 

--- a/hw/application_fpga/fw/tk1/proto.h
+++ b/hw/application_fpga/fw/tk1/proto.h
@@ -47,7 +47,7 @@ enum status {
 struct frame_header {
 	uint8_t id;
 	enum endpoints endpoint;
-	enum cmdlen len;
+	size_t len;
 };
 
 /*@ -exportlocal @*/


### PR DESCRIPTION
## Description

The frame_header has the wrong type in the struct. It is not used as the enum, it is used for the actual length.

This does note seem to change the actual binary output, but I would still argue it should be the type `size_t`. 
As it is in tkey-libs.

## Type of change

Please tick any that are relevant to this PR and remove any that aren't.

- [x] Bugfix (non breaking change which resolve an issue)

## Submission checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my changes
- [x] I have tested and verified my changes on target
- [x] My changes are well written and CI is passing
- [x] I have squashed my work to relevant commits and rebased on main for linear history
- [x] I have updated the documentation where relevant (readme, dev.tillitis.se etc.)
