### PR TITLE
Fix testbench for tk1

### DIFF
--- a/contrib/Makefile
+++ b/contrib/Makefile
@@ -40,7 +40,7 @@ run-make-spi:
 
 run-tb:
 	podman run --rm --mount type=bind,source="`pwd`/../hw/application_fpga",target=/build -w /build -it \
-	 $(IMAGE) make tb
+	 $(IMAGE) make clean_tb tb
 
 run-make-testfw:
 	podman run --rm --mount type=bind,source="`pwd`/../hw/application_fpga",target=/build -w /build -it \

--- a/hw/application_fpga/Makefile
+++ b/hw/application_fpga/Makefile
@@ -416,7 +416,7 @@ view: tb_application_fpga_vcd
 #-------------------------------------------------------------------
 # Cleanup.
 #-------------------------------------------------------------------
-clean: clean_fw
+clean: clean_fw clean_tb
 	rm -f bram_fw.hex
 	rm -f synth.{v,json,txt} route.v application_fpga.{asc,bin,vcd} application_fpga_testfw.bin
 	rm -f tb_application_fpga.vvp synth_tb.vvp route_tb.vvp
@@ -435,6 +435,15 @@ clean_fw:
 	rm -f $(TESTFW_OBJS)
 	rm -f qemu_firmware.elf
 .PHONY: clean_fw
+
+clean_tb:
+	make -C core/timer/toolruns clean
+	make -C core/tk1/toolruns clean
+	make -C core/touch_sense/toolruns clean
+	make -C core/trng/toolruns clean
+	make -C core/uart/toolruns clean
+	make -C core/uds/toolruns clean
+.PHONY: clean_tb
 
 #-------------------------------------------------------------------
 # Display info about targets.
@@ -458,6 +467,7 @@ help:
 	@echo "prog_flash_testfw  Program device flash as above, but with testfw."
 	@echo "clean              Delete all generated files."
 	@echo "clean_fw           Delete only generated files for firmware. Useful for fw devs."
+	@echo "clean_tb           Delete only generated files for testbenches."
 
 #=======================================================================
 # EOF Makefile

--- a/hw/application_fpga/core/tk1/README.md
+++ b/hw/application_fpga/core/tk1/README.md
@@ -133,7 +133,7 @@ bitstream. This allows us to generate these device unique FPGA
 bitstreams without having to do a full FPGA build.
 
 
-### RAM memory protecion
+### RAM memory protection
 
 ```
   ADDR_RAM_ADDR_RAND: 0x40
@@ -143,7 +143,7 @@ bitstreams without having to do a full FPGA build.
 These write only registers control how the data in the RAM is
 randomized as a way of protecting the data. The randomization is
 implemented using a pseudo random number generator with a state
-initalized by a seed.
+initialized by a seed.
 
 The ADDR_RAM_ADDR_RAND store the seed for how the addresses are
 randomized over the memory space. The ADDR_RAM_DATA_RAND store the

--- a/hw/application_fpga/core/tk1/tb/tb_tk1.v
+++ b/hw/application_fpga/core/tk1/tb/tb_tk1.v
@@ -83,8 +83,8 @@ module tb_tk1();
   reg           tb_cpu_valid;
   wire          tb_force_trap;
 
-  wire [14 : 0] tb_ram_aslr;
-  wire [31 : 0] tb_ram_scramble;
+  wire [14 : 0] tb_ram_addr_rand;
+  wire [31 : 0] tb_ram_data_rand;
 
   wire          tb_led_r;
   wire          tb_led_g;
@@ -129,8 +129,8 @@ module tb_tk1();
 	  .cpu_valid(tb_cpu_valid),
 	  .force_trap(tb_force_trap),
 
-	  .ram_aslr(tb_ram_aslr),
-	  .ram_scramble(tb_ram_scramble),
+	  .ram_addr_rand(tb_ram_addr_rand),
+	  .ram_data_rand(tb_ram_data_rand),
 
           .led_r(tb_led_r),
           .led_g(tb_led_g),
@@ -198,7 +198,7 @@ module tb_tk1();
 	$display("tb_cpu_trap: 0x%1x, fw_app_mode: 0x%1x", tb_cpu_trap, tb_fw_app_mode);
 	$display("cpu_addr: 0x%08x, cpu_instr: 0x%1x, cpu_valid: 0x%1x, force_tap: 0x%1x",
 		 tb_cpu_addr, tb_cpu_instr, tb_cpu_valid, tb_force_trap);
-	$display("ram_aslr: 0x%08x, ram_scramble: 0x%08x", tb_ram_aslr, tb_ram_scramble);
+	$display("ram_addr_rand: 0x%08x, ram_data_rand: 0x%08x", tb_ram_addr_rand, tb_ram_data_rand);
 	$display("led_r: 0x%1x, led_g: 0x%1x, led_b: 0x%1x", tb_led_r, tb_led_g, tb_led_b);
 	$display("ready: 0x%1x, cs: 0x%1x, we: 0x%1x, address: 0x%02x", tb_ready, tb_cs, tb_we, tb_address);
 	$display("write_data: 0x%08x, read_data: 0x%08x", tb_write_data, tb_read_data);
@@ -548,33 +548,33 @@ module tb_tk1();
 
   //----------------------------------------------------------------
   // test6()
-  // Write and RAM scrambling in fw mode.
+  // Write RAM address and data randomizatio in fw mode.
   //----------------------------------------------------------------
   task test6;
     begin
       tc_ctr = tc_ctr + 1;
 
       $display("");
-      $display("--- test6: Write RAM scrambling in fw mode.");
+      $display("--- test6: Write RAM addr and data randomization in fw mode.");
       $display("--- test6: Reset DUT to switch to fw mode.");
       reset_dut();
 
-      $display("--- test6: Write RAM ASLR and RAM SCRAMBLE.");
+      $display("--- test6: Write to ADDR_RAM_ADDR_RAND and ADDR_RAM_DATA_RAND .");
       write_word(ADDR_RAM_ADDR_RAND, 32'h13371337);
       write_word(ADDR_RAM_DATA_RAND, 32'h47114711);
 
-      $display("--- test6: Check value in dut RAM ASLR and SCRAMBLE registers.");
-      $display("--- test6: ram_aslr_reg: 0x%04x, ram_scramble_reg: 0x%08x", dut.ram_aslr_reg, dut.ram_scramble_reg);
+      $display("--- test6: Check value in dut ADDR_RAM_ADDR_RAND and ADDR_RAM_DATA_RAND registers.");
+      $display("--- test6: ram_addr_rand_reg: 0x%04x, ram_data_rand_reg: 0x%08x", dut.ram_addr_rand, dut.ram_data_rand);
 
       $display("--- test6: Switch to app mode.");
       write_word(ADDR_SWITCH_APP, 32'hf000000);
 
-      $display("--- test6: Write RAM ASLR and SCRAMBLE again.");
+      $display("--- test6: Write to ADDR_RAM_ADDR_RAND and ADDR_RAM_DATA_RAND again.");
       write_word(ADDR_RAM_ADDR_RAND, 32'hdeadbeef);
       write_word(ADDR_RAM_DATA_RAND, 32'hf00ff00f);
 
-      $display("--- test6: Check value in dut RAM ASLR and SCRAMBLE registers.");
-      $display("--- test6: ram_aslr_reg: 0x%04x, ram_scramble_reg: 0x%08x", dut.ram_aslr_reg, dut.ram_scramble_reg);
+      $display("--- test6: Check value in dut ADDR_RAM_ADDR_RAND and ADDR_RAM_DATA_RAND registers.");
+      $display("--- test6: ram_addr_rand_reg: 0x%04x, ram_data_rand_reg: 0x%08x", dut.ram_addr_rand, dut.ram_data_rand);
 
       $display("--- test6: completed.");
       $display("");


### PR DESCRIPTION
## Description

- Add clean target for the testbench generated files
- Add it so it always cleans in contrib/Makfile
- Fix broken tk1 testbench after name change

Testbenches are not running in CI yet, so run it manually using `make tb` in `hw/application_fpga` or `make run-tb` in `contrib`. 

FYI: the testbench for uds_rom is already broken, see: https://github.com/tillitis/tillitis-key1/issues/260

## Type of change

Please tick any that are relevant to this PR and remove any that aren't.

- [x] Bugfix (non breaking change which resolve an issue)

## Submission checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my changes
- [x] I have tested and verified my changes on target
- [x] My changes are well written and CI is passing
- [x] I have squashed my work to relevant commits and rebased on main for linear history
- [x] I have updated the documentation where relevant (readme, dev.tillitis.se etc.)
