### PR TITLE
Add yosys flags to optimize synthesis

### DIFF
--- a/hw/application_fpga/Makefile
+++ b/hw/application_fpga/Makefile
@@ -335,7 +335,8 @@ synth.json: $(FPGA_SRC) $(VERILOG_SRCS) $(PICORV32_SRCS) bram_fw.hex \
 		$(YOSYS_FLAG) \
 		-DBRAM_FW_SIZE=$(BRAM_FW_SIZE) \
 		-DFIRMWARE_HEX=\"$(P)/bram_fw.hex\" \
-		-p 'synth_ice40 -dsp -top application_fpga -json $@; write_verilog -attr2comment synth.v' \
+		-p 'synth_ice40 -abc2 -device u -dff -dsp -top application_fpga -json $@' \
+		-p 'write_verilog -attr2comment synth.v' \
 		$(filter %.v, $^)
 
 application_fpga_par.json: synth.json $(P)/data/$(PIN_FILE)

--- a/hw/application_fpga/application_fpga.bin.sha256
+++ b/hw/application_fpga/application_fpga.bin.sha256
@@ -1,1 +1,1 @@
-8dcd61bda632cee5a11c2eb1fc2b36f4948a9ef872e5826b23cc147c8bd2c975  application_fpga.bin
+6585aafa13727dc5bf560f34c457048ca3d13ee6ab502c2afc737b1e70fa5a00  application_fpga.bin


### PR DESCRIPTION
## Description

  * -abc2, run two passes of 'abc' for slightly improved logic density
  * -device u, optimize timing for up5k device
  * -dff, run 'abc'/'abc9' with -dff (D flip flop) option

## Type of change

- [X] Feature (non breaking change which adds functionality)

## Submission checklist

- [ ] My code follows the style guidelines of this project
- [X] I have performed a self-review of my changes
- [x] I have tested and verified my changes on target
- [ ] My changes are well written and CI is passing
- [ ] I have squashed my work to relevant commits and rebased on main for linear history
- [ ] I have added a "Co-authored-by: x" if several people contributed, either pair programming or by squashing commits from different authors.
- [ ] I have updated the documentation where relevant (readme, dev.tillitis.se etc.)
- [ ] QEMU is updated to reflect changes
