### PR TITLE
contrib: Add tkey-app-builder

### DIFF
--- a/contrib/Dockerfile.app
+++ b/contrib/Dockerfile.app
@@ -1,0 +1,9 @@
+FROM alpine:3.20
+
+RUN apk add --no-cache \
+    clang \
+    clang-extra-tools \
+    go \
+    lld \
+    llvm \
+    make

--- a/contrib/Makefile
+++ b/contrib/Makefile
@@ -4,8 +4,12 @@
 # image produced by build-image targets
 BUILDIMAGE=tkey-builder-local
 
+BUILDAPPIMAGE=tkey-app-builder-local
+
 # default image used when running a container
 IMAGE=ghcr.io/tillitis/tkey-builder:4
+
+APPIMAGE=ghcr.io/tillitis/tkey-app-builder-local
 
 all:
 	@echo "Targets:"
@@ -14,10 +18,12 @@ all:
 	@echo "run-tb                Run all the testbenches using image '$(IMAGE)' (Podman)"
 	@echo "run-make-no-clean     Like run-make but without cleaning first, useful for iterative firmware dev"
 	@echo "run-make-clean_fw     Like run-make but cleans only firmware"
+	@echo "run-app               Run the $(BUILDAPPIMAGE) for app development"
 	@echo "flash                 Program the SPI flash on the TKey - needs an existing bitstream"
 	@echo "pull                  Pull down the image '$(IMAGE)' (Podman)"
 	@echo "build-image           Build a toolchain image named '$(BUILDIMAGE)' (Podman)"
 	@echo "                      A newly built image can be used like: make IMAGE=$(BUILDIMAGE) run"
+	@echo "build-app-image       Build a app's toolchain image named '$(BUILDAPPIMAGE)' (Podman)"
 	@echo "docker-run            Run a shell using image '$(IMAGE)' (Docker)"
 	@echo "docker-build-image    Build a toolchain image named '$(BUILDIMAGE)' (Docker)"
 
@@ -49,6 +55,10 @@ run-make-clean_fw:
 	podman run --rm --mount type=bind,source="`pwd`/../hw/application_fpga",target=/build -w /build -it \
 	 $(IMAGE) make clean_fw application_fpga.bin
 
+run-app:
+	podman run --rm --mount type=bind,source="`pwd`/../",target=/build -w /build -it \
+	 $(APPIMAGE)
+
 flash:
 	podman run --rm \
 	--device /dev/bus/usb/$(lsusb | grep -m 1 1209:8886 | awk '{ printf "%s/%s", $2, substr($4,1,3) }') \
@@ -62,6 +72,9 @@ pull:
 
 build-image:
 	podman build -t $(BUILDIMAGE) .
+
+build-app-image:
+	podman build -t $(BUILDAPPIMAGE) -f Dockerfile.app
 
 docker-build-image:
 	docker build -t $(BUILDIMAGE) .


### PR DESCRIPTION
## Description

WIP: Add a new OCI container tkey-app-builder

Container tkey-app-builder for app development, both client and device apps.

Adds definition in Dockerfile.app, build, and run targets.

NOTE WELL: Experiment using Alpine as base.

Not sure if this should live in this repo or somewhere else. Perhaps under tkey-devtools like the qemu image?

Fixes # (issues)

## Type of change

Please tick any that are relevant to this PR and remove any that aren't.

- [ ] Bugfix (non breaking change which resolve an issue)
- [ ] Feature (non breaking change which adds functionality)
- [ ] Breaking Change (a change which would cause existing functionality to not work as expected)
- [ ] Documentation (a change to documentation)

## Submission checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my changes
- [ ] I have tested and verified my changes on target
- [ ] My changes are well written and CI is passing
- [ ] I have squashed my work to relevant commits and rebased on main for linear history
- [ ] I have added a "Co-authored-by: x" if several people contributed, either pair programming or by squashing commits from different authors.
- [ ] I have updated the documentation where relevant (readme, dev.tillitis.se etc.)
- [ ] QEMU is updated to reflect changes
