### PR TITLE
Update PicoRV32 clock frequency to 24 MHz

### DIFF
--- a/hw/application_fpga/Makefile
+++ b/hw/application_fpga/Makefile
@@ -28,7 +28,7 @@ ICESTORM_PATH ?=
 
 # FPGA target frequency. Should be in sync with the clock frequency
 # given by the parameters to the PLL in rtl/clk_reset_gen.v
-TARGET_FREQ ?= 21
+TARGET_FREQ ?= 24
 
 # Size in 32-bit words, must be divisible by 256 (pairs of EBRs, because 16
 # bits wide; an EBR is 128 32-bits words)
@@ -343,6 +343,7 @@ application_fpga_par.json: synth.json $(P)/data/$(PIN_FILE)
 	$(NEXTPNR_PATH)nextpnr-ice40 \
 		-l application_fpga_par.txt \
 		--freq $(TARGET_FREQ) \
+		--seed 16124898615009538779 \
 		--ignore-loops \
 		--up5k \
 		--package sg48 \

--- a/hw/application_fpga/core/clk_reset_gen/rtl/clk_reset_gen.v
+++ b/hw/application_fpga/core/clk_reset_gen/rtl/clk_reset_gen.v
@@ -76,13 +76,13 @@ module clk_reset_gen #(
   //
   // F_pllout == (F_referenceclk * (DIVF + 1)) / (2^DIVQ * (DIVR + 1))
   //
-  // Given the 12 MHz HFOSC clock set above, we get a final 21 MHz:
+  // Given the 12 MHz HFOSC clock set above, we get a final 24 MHz:
   //
-  // (12000000 * (55 + 1)) / (2^5 * (0 + 1)) = 21000000
+  // (12000000 * (63 + 1)) / (2^5 * (0 + 1)) = 24000000
   SB_PLL40_CORE #(
       .FEEDBACK_PATH("SIMPLE"),
       .DIVR(4'd0),  // DIVR =  0
-      .DIVF(7'd55),  // DIVF = 55
+      .DIVF(7'd63),  // DIVF = 63
       .DIVQ(3'd5),  // DIVQ =  5
       .FILTER_RANGE(3'b001)  // FILTER_RANGE = 1
   ) pll_inst (

--- a/hw/application_fpga/core/trng/README.md
+++ b/hw/application_fpga/core/trng/README.md
@@ -81,9 +81,9 @@ the implementation:
 - 16 oscillators in each group
 - 64 bits collected before setting the ready flag
 
-With the TKey device running at 18 MHz this means that we sample bits
-at 4.3 kbps. Since we sample twice to produce a single bit, the
-effective raw bitrate is 2.1 kbps.
+With the TKey device running at 24 MHz this means that we sample bits
+at 5.8 kbps. Since we sample twice to produce a single bit, the
+effective raw bitrate is 2.9 kbps.
 
 The 64 bits collected means that there is a separation of at least 32
 collected entropy bits between bits in the words read out.

--- a/hw/application_fpga/core/uart/rtl/uart.v
+++ b/hw/application_fpga/core/uart/rtl/uart.v
@@ -83,10 +83,10 @@ module uart (
   // The default bit rate is based on target clock frequency
   // divided by the bit rate times in order to hit the
   // center of the bits. I.e.
-  // Clock: 21 MHz, 62500 bps
-  // Divisor = 21E6 / 62500 = 336
+  // Clock: 24 MHz, 62500 bps
+  // Divisor = 24E6 / 62500 = 384
   // This also satisfies 1E6 % bps == 0 for the CH552 MCU used for USB-serial
-  localparam DEFAULT_BIT_RATE = 16'd336;
+  localparam DEFAULT_BIT_RATE = 16'd384;
   localparam DEFAULT_DATA_BITS = 4'h8;
   localparam DEFAULT_STOP_BITS = 2'h1;
 

--- a/hw/application_fpga/fw/testfw/main.c
+++ b/hw/application_fpga/fw/testfw/main.c
@@ -311,8 +311,8 @@ int main(void)
 	}
 
 	puts("\r\nTesting timer... 3");
-	// Matching clock at 18 MHz, giving us timer in seconds
-	*timer_prescaler = 18 * 1000000;
+	// Matching clock at 24 MHz, giving us timer in seconds
+	*timer_prescaler = 24 * 1000000;
 
 	// Test timer expiration after 1s
 	*timer = 1;


### PR DESCRIPTION
## Description

Update PicoRV32 clock frequency to 24 MHz and include a seed value for nextpnr to get a layout that reaches 24 MHz.

## Type of change

Please tick any that are relevant to this PR and remove any that aren't.

- [ ] Bugfix (non breaking change which resolve an issue)
- [X] Feature (non breaking change which adds functionality)
- [ ] Breaking Change (a change which would cause existing functionality to not work as expected)
- [ ] Documentation (a change to documentation)

## Submission checklist

- [ ] My code follows the style guidelines of this project
- [X] I have performed a self-review of my changes
- [X] I have tested and verified my changes on target
- [ ] My changes are well written and CI is passing
- [ ] I have squashed my work to relevant commits and rebased on main for linear history
- [ ] I have added a "Co-authored-by: x" if several people contributed, either pair programming or by squashing commits from different authors.
- [ ] I have updated the documentation where relevant (readme, dev.tillitis.se etc.)
- [ ] QEMU is updated to reflect changes
