### PR TITLE
CI: remove the use of our container in check-hashes job

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -114,8 +114,6 @@ jobs:
   check-hashes:
     needs: build-bitstream
     runs-on: ubuntu-latest
-    container:
-      image: ghcr.io/tillitis/tkey-builder:4
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -110,6 +110,7 @@ jobs:
             hw/application_fpga/application_fpga.bin
             hw/application_fpga/firmware.bin
           key: build-${{ github.run_number }}-${{ github.sha }}-${{ github.run_attempt }}
+          enableCrossOsArchive: true
 
   check-hashes:
     needs: build-bitstream
@@ -128,6 +129,7 @@ jobs:
             hw/application_fpga/firmware.bin
           key: build-${{ github.run_number }}-${{ needs.build-bitstream.outputs.commit_sha }}-${{ github.run_attempt }}
           fail-on-cache-miss: true
+          enableCrossOsArchive: true
 
       - name: check matching hashes for firmware.bin & application_fpga.bin
         working-directory: hw/application_fpga

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -109,7 +109,7 @@ jobs:
           path: |
             hw/application_fpga/application_fpga.bin
             hw/application_fpga/firmware.bin
-          key: build-${{ github.run_number }}-${{ github.sha }}-${{ github.run_attempt }}
+          key: cross-os-build-${{ github.sha }}
           enableCrossOsArchive: true
 
   check-hashes:
@@ -127,7 +127,7 @@ jobs:
           path: |
             hw/application_fpga/application_fpga.bin
             hw/application_fpga/firmware.bin
-          key: build-${{ github.run_number }}-${{ needs.build-bitstream.outputs.commit_sha }}-${{ github.run_attempt }}
+          key: cross-os-build-${{ needs.build-bitstream.outputs.commit_sha }}
           fail-on-cache-miss: true
           enableCrossOsArchive: true
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -127,6 +127,7 @@ jobs:
             hw/application_fpga/application_fpga.bin
             hw/application_fpga/firmware.bin
           key: build-${{ github.run_number }}-${{ needs.build-bitstream.outputs.commit_sha }}-${{ github.run_attempt }}
+          fail-on-cache-miss: true
 
       - name: check matching hashes for firmware.bin & application_fpga.bin
         working-directory: hw/application_fpga


### PR DESCRIPTION
The container is not needed for that simple job, but it takes quite some time to set it up for each run.

## Description

Please include a summary of the changes made in this PR and provide any context necessary for the change.

Fixes # (issues)

## Type of change

Please tick any that are relevant to this PR and remove any that aren't.

- [ ] Bugfix (non breaking change which resolve an issue)
- [ ] Feature (non breaking change which adds functionality)
- [ ] Breaking Change (a change which would cause existing functionality to not work as expected)
- [ ] Documentation (a change to documentation)

## Submission checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my changes
- [ ] I have tested and verified my changes on target
- [ ] My changes are well written and CI is passing
- [ ] I have squashed my work to relevant commits and rebased on main for linear history
- [ ] I have added a "Co-authored-by: x" if several people contributed, either pair programming or by squashing commits from different authors.
- [ ] I have updated the documentation where relevant (readme, dev.tillitis.se etc.)
- [ ] QEMU is updated to reflect changes
