### PR TITLE
Remove duplicate entries in default values assignment of tk1 api

### DIFF
--- a/hw/application_fpga/core/tk1/rtl/tk1.v
+++ b/hw/application_fpga/core/tk1/rtl/tk1.v
@@ -422,14 +422,12 @@ module tk1 (
     app_size_we      = 1'h0;
     blake2s_addr_we  = 1'h0;
     cdi_mem_we       = 1'h0;
-    cdi_mem_we       = 1'h0;
     ram_addr_rand_we = 1'h0;
     ram_data_rand_we = 1'h0;
     system_reset_new = 1'h0;
     cpu_mon_en_we    = 1'h0;
     cpu_mon_first_we = 1'h0;
     cpu_mon_last_we  = 1'h0;
-    cpu_mon_en_we    = 1'h0;
     tmp_read_data    = 32'h0;
     tmp_ready        = 1'h0;
 


### PR DESCRIPTION
## Description
cpu_mon_en_we and cdi_mem_we was set twice in the tk1 api

Fixes # (issues)

## Type of change
- [x] Bugfix (non breaking change which resolve an issue)

## Submission checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my changes
- [ ] I have tested and verified my changes on target
- [ ] My changes are well written and CI is passing
- [ ] I have squashed my work to relevant commits and rebased on main for linear history
- [ ] I have added a "Co-authored-by: x" if several people contributed, either pair programming or by squashing commits from different authors.
- [ ] I have updated the documentation where relevant (readme, dev.tillitis.se etc.)
- [ ] QEMU is updated to reflect changes
