### PR TITLE
Add nextpnr flag '--exit-on-failed-target-frequency'

### DIFF
--- a/contrib/Dockerfile
+++ b/contrib/Dockerfile
@@ -100,8 +100,24 @@ WORKDIR /src
 # Add "Fix handling of RNG seed" #1369
 RUN git cherry-pick --no-commit 6ca64526bb18ace8690872b09ca1251567c116de
 # Add early exit if place fails on timing
-RUN sed -i 's/if (do_route) {/if (do_route \&\& !had_nonfatal_error) {/' common/kernel/command.cc
-RUN sed -i 's/bool warn_on_failure = false/bool warn_on_failure = true/' common/kernel/timing.h
+RUN sed -i \
+    '345i \ \ \ \ general.add_options()("exit-on-failed-target-frequency",' \
+    common/kernel/command.cc
+RUN sed -i \
+    '346i \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ "exit if target frequency is not achieved (use together with "' \
+    common/kernel/command.cc
+RUN sed -i \
+    '347i \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ "--randomize-seed option)");' \
+    common/kernel/command.cc
+RUN sed -i \
+    '348i \\' \
+    common/kernel/command.cc
+RUN sed -i \
+    '662s/if (do_route) {/if (do_route \&\& (vm.count("exit-on-failed-target-frequency") ? !had_nonfatal_error : true)) {/' \
+    common/kernel/command.cc
+RUN sed -i \
+    '244s/bool warn_on_failure = false/bool warn_on_failure = true/' \
+    common/kernel/timing.h
 RUN cmake -DARCH=ice40 . \
     && make -j$(nproc --ignore=2) \
     && make install \

--- a/contrib/Dockerfile
+++ b/contrib/Dockerfile
@@ -72,8 +72,8 @@ RUN git clone --depth=1 https://github.com/YosysHQ/icestorm /src
 WORKDIR /src
 RUN git checkout 738af822905fdcf0466e9dd784b9ae4b0b34987f \
     && make -j$(nproc --ignore=2) \
-    && make install
-RUN git describe --all --always --long --dirty > /usr/local/repo-commit-icestorm
+    && make install \
+    && git describe --all --always --long --dirty > /usr/local/repo-commit-icestorm
 WORKDIR /
 RUN rm -rf /src
 
@@ -81,8 +81,8 @@ RUN rm -rf /src
 RUN git clone -b interfaces --depth=1 https://github.com/tillitis/icestorm /src
 WORKDIR /src/iceprog
 RUN make -j$(nproc --ignore=2) \
-    && make PROGRAM_PREFIX=tillitis- install
-RUN git describe --all --always --long --dirty > /usr/local/repo-commit-tillitis--icestorm
+    && make PROGRAM_PREFIX=tillitis- install \
+    && git describe --all --always --long --dirty > /usr/local/repo-commit-tillitis--icestorm
 WORKDIR /
 RUN rm -rf /src
 
@@ -90,8 +90,8 @@ RUN git clone -b 0.45 --depth=1 https://github.com/YosysHQ/yosys /src
 WORKDIR /src
 RUN git submodule update --init \
     && make -j$(nproc --ignore=2) \
-    && make install
-RUN git describe --all --always --long --dirty > /usr/local/repo-commit-yosys
+    && make install \
+    && git describe --all --always --long --dirty > /usr/local/repo-commit-yosys
 WORKDIR /
 RUN rm -rf /src
 
@@ -104,8 +104,8 @@ RUN sed -i 's/if (do_route) {/if (do_route \&\& !had_nonfatal_error) {/' common/
 RUN sed -i 's/bool warn_on_failure = false/bool warn_on_failure = true/' common/kernel/timing.h
 RUN cmake -DARCH=ice40 . \
     && make -j$(nproc --ignore=2) \
-    && make install
-RUN git describe --all --always --long --dirty > /usr/local/repo-commit-nextpnr
+    && make install \
+    && git describe --all --always --long --dirty > /usr/local/repo-commit-nextpnr
 WORKDIR /
 RUN rm -rf /src
 
@@ -114,8 +114,8 @@ WORKDIR /src
 RUN sh autoconf.sh \
     && ./configure \
     && make -j$(nproc --ignore=2) \
-    && make install
-RUN git describe --all --always --long --dirty > /usr/local/repo-commit-iverilog
+    && make install \
+    && git describe --all --always --long --dirty > /usr/local/repo-commit-iverilog
 WORKDIR /
 RUN rm -rf /src
 
@@ -125,8 +125,8 @@ RUN autoconf \
     && ./configure \
     && make -j$(nproc --ignore=2) \
     && make test \
-    && make install
-RUN git describe --all --always --long --dirty > /usr/local/repo-commit-verilator
+    && make install \
+    && git describe --all --always --long --dirty > /usr/local/repo-commit-verilator
 WORKDIR /
 RUN rm -rf /src
 
@@ -140,8 +140,8 @@ RUN rm -rf /src
 
 RUN git clone -b v1.9.1 https://github.com/cocotb/cocotb.git /src
 WORKDIR /src
-RUN pip install . --break-system-packages
-RUN git describe --all --always --long --dirty > /usr/local/repo-commit-cocotb
+RUN pip install . --break-system-packages \
+    && git describe --all --always --long --dirty > /usr/local/repo-commit-cocotb
 WORKDIR /
 RUN rm -rf /src
 

--- a/hw/application_fpga/tools/run_pnr.sh
+++ b/hw/application_fpga/tools/run_pnr.sh
@@ -67,6 +67,7 @@ start_thread() {
                 --log $LOG_FILE \
                 --randomize-seed \
                 --freq $FREQ \
+                --exit-on-failed-target-frequency \
                 --ignore-loops \
                 --up5k \
                 --package $PACKAGE \


### PR DESCRIPTION
## Description

* Add flag so we can keep nextpnr standard behavior and if this flag is used we can get a fast exit if timing fails on placement.

* Update run_pnr.sh script to use this flag

## Type of change

Please tick any that are relevant to this PR and remove any that aren't.

- [ ] Bugfix (non breaking change which resolve an issue)
- [X] Feature (non breaking change which adds functionality)
- [ ] Breaking Change (a change which would cause existing functionality to not work as expected)
- [ ] Documentation (a change to documentation)

## Submission checklist

- [ ] My code follows the style guidelines of this project
- [X] I have performed a self-review of my changes
- [ ] I have tested and verified my changes on target
- [ ] My changes are well written and CI is passing
- [ ] I have squashed my work to relevant commits and rebased on main for linear history
- [ ] I have added a "Co-authored-by: x" if several people contributed, either pair programming or by squashing commits from different authors.
- [ ] I have updated the documentation where relevant (readme, dev.tillitis.se etc.)
- [ ] QEMU is updated to reflect changes
