### PR TITLE
Doc: fix typo of system mode in readme

### DIFF
--- a/hw/application_fpga/core/fw_ram/README.md
+++ b/hw/application_fpga/core/fw_ram/README.md
@@ -21,6 +21,6 @@ The contents of the fw_ram is cleared when the FPGA is powered up and
 configured by the bitstream. The contents is not cleared by a system
 reset.
 
-If the system_mode input is set, i.e. in firmware mode, no memory
+If the system_mode input is set, i.e. in app mode, no memory
 accesses are allowed. Any reads when the system_mode is set will
 return an all zero word.


### PR DESCRIPTION
## Description
fix typo of system mode in readme

## Type of change
- [x] Documentation (a change to documentation)

## Submission checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my changes
- [ ] I have tested and verified my changes on target
- [ ] My changes are well written and CI is passing
- [ ] I have squashed my work to relevant commits and rebased on main for linear history
- [ ] I have added a "Co-authored-by: x" if several people contributed, either pair programming or by squashing commits from different authors.
- [ ] I have updated the documentation where relevant (readme, dev.tillitis.se etc.)
- [ ] QEMU is updated to reflect changes
