### PR TITLE
Fix off-by-one UART bitrate counter value

### DIFF
--- a/hw/application_fpga/application_fpga.bin.sha256
+++ b/hw/application_fpga/application_fpga.bin.sha256
@@ -1,1 +1,1 @@
-44086edb70377991b57d3f1c231f743fcf0c2c9d2303843ec133f76cc42449a8  application_fpga.bin
+f66159016ebbc98e07d0a1cb01d779d0e898eaba3a718576ca7f894f7fab7b85  application_fpga.bin


### PR DESCRIPTION
## Description

Fix off-by-one UART bitrate counter value that will make the RX sampling and TX sending drift. The impact gets higher as the baudrate increases and the bitrate counter value gets smaller.

## Type of change

Please tick any that are relevant to this PR and remove any that aren't.

- [X] Bugfix (non breaking change which resolve an issue)

## Submission checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my changes
- [X] I have tested and verified my changes on target
- [x] My changes are well written and CI is passing
- [ ] I have squashed my work to relevant commits and rebased on main for linear history
