### PR TITLE
Build: Don't depend on uds.hex and udi.hex

### DIFF
--- a/hw/application_fpga/Makefile
+++ b/hw/application_fpga/Makefile
@@ -353,8 +353,7 @@ tb:
 
 YOSYS_FLAG ?=
 
-synth.json: $(FPGA_VERILOG_SRCS) $(VERILOG_SRCS) $(PICORV32_SRCS) bram_fw.hex \
-		$(P)/data/uds.hex $(P)/data/udi.hex
+synth.json: $(FPGA_VERILOG_SRCS) $(VERILOG_SRCS) $(PICORV32_SRCS) bram_fw.hex
 	$(YOSYS_PATH)yosys \
 		-v3 \
 		-l synth.txt \


### PR DESCRIPTION
## Description

synth.json shouldn't depend on uds.hex and udi.hex because that triggers a complete rebuild of the bitstream if the UDI or UDS are changed.

Instead, we want only the `application_fpga.asc` target to depend on them, so it can patch in the changed UDS and UDI with `tools/patch_uds_udi.py` in an existing `application_fpga_par.json`.

## Type of change

Please tick any that are relevant to this PR and remove any that aren't.

- [x] Bugfix (non breaking change which resolve an issue)

## Submission checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my changes
- [ ] I have tested and verified my changes on target
- [ ] My changes are well written and CI is passing
- [ ] I have squashed my work to relevant commits and rebased on main for linear history
- [ ] I have added a "Co-authored-by: x" if several people contributed, either pair programming or by squashing commits from different authors.
- [ ] I have updated the documentation where relevant (readme, dev.tillitis.se etc.)
- [ ] QEMU is updated to reflect changes
