### PR TITLE
ch552: Fix race condition + misc. stuff

### DIFF
--- a/hw/usb_interface/ch552_fw/include/debug.c
+++ b/hw/usb_interface/ch552_fw/include/debug.c
@@ -254,13 +254,13 @@ void gpio_init_p1_5_out()
                         //        1 = Pull-up resistor enabled
 }
 
-// Set p1.5 high
+// Set pin 1.5 high
 void gpio_p1_5_set(void)
 {
-    P1 |= 0x20; // p1.4
+    P1 |= 0x20;
 }
 
-// Set p1.5 low
+// Set pin 1.5 low
 void gpio_p1_5_unset(void)
 {
     P1 &= ~0x20;

--- a/hw/usb_interface/ch552_fw/include/debug.h
+++ b/hw/usb_interface/ch552_fw/include/debug.h
@@ -29,13 +29,11 @@
 //Std  1000000   1000000     0.00%
 
 #ifndef UART0_BAUD
-//#define UART0_BAUD    115200
 #define UART0_BAUD      1000000
 #endif
 
 #ifndef UART1_BAUD
 #define UART1_BAUD      500000
-//#define UART1_BAUD    1000000
 #endif
 
 void CfgFsys(void);        // CH554 clock selection and configuration
@@ -148,8 +146,8 @@ inline void UART1Setup()
     U1SM0 = 0;    // UART1 selects 8-bit data bit
     U1SMOD = 1;   // Fast mode
     U1REN = 1;    // Enable receiving
-                  // Should correct for rounding in SBAUD1 calculation
-    SBAUD1 = 256 - FREQ_SYS/16/UART1_BAUD; // Calculation for Fast mode
+    uint32_t val = FREQ_SYS/16/UART1_BAUD; // Calculation for Fast mode
+    SBAUD1 = 256 - val;                    // Calculation for Fast mode
     IE_UART1 = 1; // Enable UART1 interrupt
     IP_EX = bIP_UART1; // Serial port IRQ has high priority
 }

--- a/hw/usb_interface/ch552_fw/main.c
+++ b/hw/usb_interface/ch552_fw/main.c
@@ -1375,9 +1375,9 @@ void main()
                        CdcRxBuf,
                        CdcRxBufLength);
 
+                Endpoint2UploadBusy = 1; // Set busy flag
                 UEP2_T_LEN = CdcRxBufLength; // Set the number of data bytes that Endpoint 2 is ready to send
                 UEP2_CTRL = (UEP2_CTRL & ~MASK_UEP_T_RES) | UEP_T_RES_ACK; // Answer ACK
-                Endpoint2UploadBusy = 1; // Set busy flag
 
                 CdcDataAvailable = 0;
                 CdcRxBufLength = 0;
@@ -1396,9 +1396,9 @@ void main()
                        HidRxBuf,
                        HidRxBufLength);
 
+                Endpoint3UploadBusy = 1; // Set busy flag
                 UEP3_T_LEN = MAX_PACKET_SIZE; // Set the number of data bytes that Endpoint 3 is ready to send
                 UEP3_CTRL = (UEP3_CTRL & ~MASK_UEP_T_RES) | UEP_T_RES_ACK; // Answer ACK
-                Endpoint3UploadBusy = 1; // Set busy flag
 
                 HidDataAvailable = 0;
 
@@ -1422,9 +1422,9 @@ void main()
                             TkeyCtrlRxBufLength);
                 }
 
+                Endpoint4UploadBusy = 1; // Set busy flag
                 UEP4_T_LEN = MAX_PACKET_SIZE; // Set the number of data bytes that Endpoint 4 is ready to send
                 UEP4_CTRL = (UEP4_CTRL & ~MASK_UEP_T_RES) | UEP_T_RES_ACK; // Answer ACK
-                Endpoint4UploadBusy = 1; // Set busy flag
 
                 TkeyCtrlDataAvailable = 0;
                 TkeyCtrlRxBufLength = 0;


### PR DESCRIPTION
## Description

- Move "EndpointXUploadBusy = 1" to before USB transfer is started to fix race with USB transfer complete interrupt.

- Move copying of TKEYCTRL data from UartRxBuf to TkeyCtrlRxBuf to align with previous code.

- Remove obsolete UartRxBufOverflow variable.

- Add missing Endpoint4 handling for USB bus reset.

- Fix more robust uart_byte_count() calculation.

- Fix baudrate fast mode calculation to get rid of compiler warning.

- Fix assignment of bUD_PD_DIS to UDEV_CTRL.

- Cleanup comments.

Fixes #319 

## Type of change

Please tick any that are relevant to this PR and remove any that aren't.

- [x] Bugfix (non breaking change which resolve an issue)
- [ ] Feature (non breaking change which adds functionality)
- [ ] Breaking Change (a change which would cause existing functionality to not work as expected)
- [ ] Documentation (a change to documentation)

## Submission checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my changes
- [x] I have tested and verified my changes on target
- [ ] My changes are well written and CI is passing
- [ ] I have squashed my work to relevant commits and rebased on main for linear history
- [ ] I have added a "Co-authored-by: x" if several people contributed, either pair programming or by squashing commits from different authors.
- [ ] I have updated the documentation where relevant (readme, dev.tillitis.se etc.)
- [ ] QEMU is updated to reflect changes
