### PR TITLE
Simplify flashing bitstream, partition table and testloadapp.bin

### DIFF
--- a/contrib/Makefile
+++ b/contrib/Makefile
@@ -14,7 +14,7 @@ all:
 	@echo "run-tb                Run all the testbenches using image '$(IMAGE)' (Podman)"
 	@echo "run-make-no-clean     Like run-make but without cleaning first, useful for iterative firmware dev"
 	@echo "run-make-clean_fw     Like run-make but cleans only firmware"
-	@echo "flash                 Program the SPI flash on the TKey - needs an existing bitstream"
+	@echo "flash                 Build bitstream and testloadapp.bin then program them and the partition table onto the TKey SPI flash"
 	@echo "pull                  Pull down the image '$(IMAGE)' (Podman)"
 	@echo "build-image           Build a toolchain image named '$(BUILDIMAGE)' (Podman)"
 	@echo "                      A newly built image can be used like: make IMAGE=$(BUILDIMAGE) run"
@@ -54,7 +54,7 @@ flash:
 	--device /dev/bus/usb/$(lsusb | grep -m 1 1209:8886 | awk '{ printf "%s/%s", $2, substr($4,1,3) }') \
 	--mount type=bind,source="`pwd`/../hw/application_fpga",target=/build \
 	-w /build \
-	-it $(IMAGE) tillitis-iceprog /build/application_fpga.bin
+	-it $(IMAGE) make prog_flash
 
 
 pull:

--- a/hw/application_fpga/Makefile
+++ b/hw/application_fpga/Makefile
@@ -473,7 +473,13 @@ tb_application_fpga: $(SIM_VERILOG_SRCS) \
 
 prog_flash: check-hardware application_fpga.bin
 	tillitis-iceprog application_fpga.bin
+	make -C apps
+	(cd tools && ./load_preloaded_app.sh 0 ../apps/testloadapp.bin)
 .PHONY: prog_flash
+
+prog_flash_bs: check-hardware application_fpga.bin
+	tillitis-iceprog application_fpga.bin
+.PHONY: prog_flash_bs
 
 prog_flash_testfw: check-hardware application_fpga_testfw.bin
 	tillitis-iceprog application_fpga_testfw.bin
@@ -506,6 +512,7 @@ clean: clean_sim clean_fw clean_tb
 	rm -f lint_issues.txt
 	rm -f tools/tpt/*.hex
 	rm -rf tools/tpt/__pycache__
+	make -C apps clean
 .PHONY: clean
 
 clean_fw:
@@ -554,7 +561,8 @@ help:
 	@echo "tb_application_fpga  Build testbench simulation for the design"
 	@echo "lint                 Run lint on Verilog source files."
 	@echo "tb                   Run all testbenches"
-	@echo "prog_flash           Program device flash with FGPA bitstream including firmware (using the RPi Pico-based programmer)."
+	@echo "prog_flash           Program device flash with FGPA bitstream (including firmware), partition table, and testloadapp.bin (using the RPi Pico-based programmer)."
+	@echo "prog_flash_bs        Program device flash with FGPA bitstream including firmware (using the RPi Pico-based programmer)."
 	@echo "prog_flash_testfw    Program device flash as above, but with testfw."
 	@echo "clean                Delete all generated files."
 	@echo "clean_fw             Delete only generated files for firmware. Useful for fw devs."

--- a/hw/application_fpga/Makefile
+++ b/hw/application_fpga/Makefile
@@ -472,17 +472,17 @@ tb_application_fpga: $(SIM_VERILOG_SRCS) \
 #-------------------------------------------------------------------
 
 prog_flash: check-hardware application_fpga.bin
-	sudo tillitis-iceprog application_fpga.bin
+	tillitis-iceprog application_fpga.bin
 .PHONY: prog_flash
 
 prog_flash_testfw: check-hardware application_fpga_testfw.bin
-	sudo tillitis-iceprog application_fpga_testfw.bin
+	tillitis-iceprog application_fpga_testfw.bin
 .PHONY: prog_flash_testfw
 
 check-hardware:
-	@sudo tillitis-iceprog -t >/dev/null 2>&1 || \
+	@tillitis-iceprog -t >/dev/null 2>&1 || \
 	{ echo "Programmer not plugged in or not accessible"; false; }
-	@if sudo tillitis-iceprog -t 2>&1 | grep -qi "^flash.id:\( 0x\(00\|ff\)\)\{4\}"; then \
+	@if tillitis-iceprog -t 2>&1 | grep -qi "^flash.id:\( 0x\(00\|ff\)\)\{4\}"; then \
 	echo "No USB stick in the programmer?"; false; else true; fi
 .PHONY: check-hardware
 


### PR DESCRIPTION
## Description

Simplifies the process of getting a TKey into a functional state out of the box.

Instead of building and flashing bitstream, partition table and testloadapp.bin separately you can now run `make -C contrib flash` or `make -C hw/application prog_flash`.

Also removes the use of sudo in the tillitis-iceprog calls. It should not be needed if proper permissions has been setup for the tp-1.

## Type of change

Please tick any that are relevant to this PR and remove any that aren't.

- [x] Feature (non breaking change which adds functionality)
- [x] Breaking Change (a change which would cause existing functionality to not work as expected)
- [x] Documentation (a change to documentation)

## Submission checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my changes
- [x] I have tested and verified my changes on target
- [x] My changes are well written and CI is passing
- [x] I have squashed my work to relevant commits and rebased on main for linear history
- [x] I have added a "Co-authored-by: x" if several people contributed, either pair programming or by squashing commits from different authors.
- [x] I have updated the documentation where relevant (readme, dev.tillitis.se etc.)
- [ ] QEMU is updated to reflect changes