### PR TITLE
Fix qemu_firmware build warnings

### DIFF
--- a/hw/application_fpga/fw/tk1/main.c
+++ b/hw/application_fpga/fw/tk1/main.c
@@ -449,11 +449,11 @@ static enum state start_where(struct context *ctx)
 	debug_lf();
 
 	debug_puts("  ->app_digest: \n");
-	debug_hexdump(resetinfo->app_digest, RESET_DIGEST_SIZE);
+	debug_hexdump((void *)resetinfo->app_digest, RESET_DIGEST_SIZE);
 	debug_lf();
 
 	debug_puts("  ->next_app_data: \n");
-	debug_hexdump(resetinfo->next_app_data, RESET_DATA_SIZE);
+	debug_hexdump((void *)resetinfo->next_app_data, RESET_DATA_SIZE);
 	debug_lf();
 
 	// Where do we start?


### PR DESCRIPTION
## Description

Building `qemu_firmware.bin`:

```
cd contrib
make run
cd hw/application_fpga
make clean_fw
make qemu_firmware.elf
```

Produce the following warnings:

```
/build/hw/application_fpga/fw/tk1/main.c:452:16: warning: passing 'volatile uint8_t[32]' (aka 'volatile unsigned char[32]') to parameter of type 'void *' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
  452 |         debug_hexdump(resetinfo->app_digest, RESET_DIGEST_SIZE);
      |                       ^~~~~~~~~~~~~~~~~~~~~
tkey-libs/include/tkey/debug.h:17:50: note: expanded from macro 'debug_hexdump'
   17 | #define debug_hexdump(buf, len) hexdump(IO_QEMU, buf, len)
      |                                                  ^~~
tkey-libs/include/tkey/io.h:39:37: note: passing argument to parameter 'buf' here
   39 | void hexdump(enum ioend dest, void *buf, int len);
      |                                     ^
/build/hw/application_fpga/fw/tk1/main.c:456:16: warning: passing 'volatile uint8_t[220]' (aka 'volatile unsigned char[220]') to parameter of type 'void *' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
  456 |         debug_hexdump(resetinfo->next_app_data, RESET_DATA_SIZE);
      |                       ^~~~~~~~~~~~~~~~~~~~~~~~
tkey-libs/include/tkey/debug.h:17:50: note: expanded from macro 'debug_hexdump'
   17 | #define debug_hexdump(buf, len) hexdump(IO_QEMU, buf, len)
      |                                                  ^~~
tkey-libs/include/tkey/io.h:39:37: note: passing argument to parameter 'buf' here
   39 | void hexdump(enum ioend dest, void *buf, int len);
      |                                     ^
```

This PR fixes the warnings.

## Type of change

- [x] Bugfix (non breaking change which resolve an issue)

## Submission checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my changes
- [x] I have tested and verified my changes on target
- [x] My changes are well written and CI is passing
- [x] I have squashed my work to relevant commits and rebased on main for linear history
- [x] I have added a "Co-authored-by: x" if several people contributed, either pair programming or by squashing commits from different authors.
- [ ] I have updated the documentation where relevant (readme, dev.tillitis.se etc.)
- [ ] QEMU is updated to reflect changes
