### PR TITLE
Change size of TKey memory in QEMU to be able to debug large apps

### DIFF
--- a/hw/application_fpga/Makefile
+++ b/hw/application_fpga/Makefile
@@ -207,6 +207,8 @@ simfirmware.elf: CFLAGS += -DSIMULATION
 simfirmware.elf: $(FIRMWARE_OBJS) $(P)/fw/tk1/firmware.lds
 	$(CC) $(CFLAGS) $(FIRMWARE_OBJS) $(LDFLAGS) -o $@ > $(basename $@).map
 
+qemu_firmware.elf: CFLAGS += -DBUILD_FOR_QEMU
+qemu_firmware.elf: ASFLAGS += -DBUILD_FOR_QEMU
 qemu_firmware.elf: CFLAGS += -DQEMU_DEBUG
 qemu_firmware.elf: ASFLAGS += -DQEMU_DEBUG
 qemu_firmware.elf: CFLAGS += -DQEMU_SYSCALL

--- a/hw/application_fpga/fw/tk1/qemu_firmware.lds
+++ b/hw/application_fpga/fw/tk1/qemu_firmware.lds
@@ -11,10 +11,10 @@ STACK_SIZE = 3000;
 
 MEMORY
 {
-	ROM       (rx)  : ORIGIN = 0x00000000, LENGTH = 128k
-	FWRAM     (rw)  : ORIGIN = 0xd0000000, LENGTH = 0xF00   /* 3840 B */
-	RESETINFO (rw)  : ORIGIN = 0xd0000F00, LENGTH = 0x100   /* 256 B (part of FW_RAM area) */
-	RAM       (rwx) : ORIGIN = 0x40000000, LENGTH = 0x20000 /* 128 KB */
+	ROM       (rx)  : ORIGIN = 0x00000000, LENGTH = 0x20000  /* 128 KB */
+	FWRAM     (rw)  : ORIGIN = 0xd0000000, LENGTH = 0xF00    /* 3840 B */
+	RESETINFO (rw)  : ORIGIN = 0xd0000F00, LENGTH = 0x100    /* 256 B (part of FW_RAM area) */
+	RAM       (rwx) : ORIGIN = 0x40000000, LENGTH = 0x100000 /* 1 MB */
 }
 
 SECTIONS

--- a/hw/application_fpga/fw/tk1/start.S
+++ b/hw/application_fpga/fw/tk1/start.S
@@ -64,7 +64,7 @@ irq_source_ok:
 	// Verify that interrupt return address (x3) is in app RAM
 	li t0, TK1_RAM_BASE // 0x40000000
 	blt x3, t0, x3_invalid
-	li t0, TK1_RAM_BASE + TK1_RAM_SIZE // 0x40020000
+	li t0, TK1_RAM_BASE + TK1_RAM_SIZE
 	bge x3, t0, x3_invalid
 	j x3_valid
 x3_invalid:


### PR DESCRIPTION
## Description

This commit does parts of the changes needed to increase the size of the emulated RAM for TKey in QEMU. This is to be able to build TKey apps without optimization and do debugging with gdb through QEMU.

## Type of change

Please tick any that are relevant to this PR and remove any that aren't.

- [ ] Bugfix (non breaking change which resolve an issue)
- [X] Feature (non breaking change which adds functionality)
- [ ] Breaking Change (a change which would cause existing functionality to not work as expected)
- [ ] Documentation (a change to documentation)

## Submission checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my changes
- [X] I have tested and verified my changes on target
- [ ] My changes are well written and CI is passing
- [ ] I have squashed my work to relevant commits and rebased on main for linear history
- [ ] I have added a "Co-authored-by: x" if several people contributed, either pair programming or by squashing commits from different authors.
- [ ] I have updated the documentation where relevant (readme, dev.tillitis.se etc.)
- [ ] QEMU is updated to reflect changes
