### PR TITLE
Build multiarch docker image

### DIFF
--- a/contrib/Makefile
+++ b/contrib/Makefile
@@ -74,4 +74,4 @@ build-image:
 	podman build -t $(BUILDIMAGE) .
 
 docker-build-image:
-	docker build -t $(BUILDIMAGE) .
+	docker buildx build --platform linux/amd64,linux/arm64/8 -t $(BUILDIMAGE) .


### PR DESCRIPTION
## Description

This PR changes the docker build command to use `buildx build` instead, and specifies the platform as `linux/amd64,linux/arm64`.

This will enable macs with M1+ chips to download the prebuilt image and use it through docker desktop.

This should also enable other arm64 based systems such as raspberry pi to download and use the docker image directly.

## Type of change

Please tick any that are relevant to this PR and remove any that aren't.

- [ ] Bugfix (non breaking change which resolve an issue)
- [ ] Feature (non breaking change which adds functionality)
- [ ] Breaking Change (a change which would cause existing functionality to not work as expected)
- [ ] Documentation (a change to documentation)

## Submission checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my changes
- [x] I have tested and verified my changes on target
- [ ] My changes are well written and CI is passing
- [x] I have squashed my work to relevant commits and rebased on main for linear history
- [x] I have added a "Co-authored-by: x" if several people contributed, either pair programming or by squashing commits from different authors.
- [ ] I have updated the documentation where relevant (readme, dev.tillitis.se etc.)
- [ ] QEMU is updated to reflect changes
