### PR TITLE
doc: Update UDS core README according to implementation

### DIFF
--- a/hw/application_fpga/core/uds/README.md
+++ b/hw/application_fpga/core/uds/README.md
@@ -20,17 +20,9 @@ bit has been set after one cycle.
 
 
 ## API
-There are eight addresses in the API. These are defined by the
-two values ADDR_UDS_FIRST and ADDR_UDS_LAST:
 
-```
-	ADDR_UDS_FIRST: 0x10
-	ADDR_UDS_LAST:  0x17
-```
-
-These addresses are read only and read once between reset.
-
-Any access to another address will be ignored by the core.
+Three address bits are used. Addresses 0-7 address each of the UDS
+words. All words are read-only and read-once between reset.
 
 
 ## Implementation


### PR DESCRIPTION
## Description

This PR updates the UDS core README to reflect that:

- ADDR_UDS_FIRST and ADDR_UDS_LAST params have been removed
- The address range has been lowered to 8 words.


## Type of change

- [x] Documentation (a change to documentation)

## Submission checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my changes
- [ ] I have tested and verified my changes on target
- [ ] My changes are well written and CI is passing
- [ ] I have squashed my work to relevant commits and rebased on main for linear history
- [ ] I have added a "Co-authored-by: x" if several people contributed, either pair programming or by squashing commits from different authors.
- [ ] I have updated the documentation where relevant (readme, dev.tillitis.se etc.)
- [ ] QEMU is updated to reflect changes
