### PR TITLE
General Ch552 improvements

### DIFF
--- a/hw/usb_interface/ch552_fw/src/main.c
+++ b/hw/usb_interface/ch552_fw/src/main.c
@@ -682,8 +682,8 @@ IDATA uint8_t FrameDiscard = 0;
 IDATA uint8_t DiscardDataAvailable = 0;
 
 static void memcpy_local(void *dst, const void *src, uint8_t len);
-uint32_t increment_pointer(uint32_t pointer, uint32_t increment, uint32_t buffer_size);
-uint32_t decrement_pointer(uint32_t pointer, uint32_t decrement, uint32_t buffer_size);
+uint8_t increment_pointer(uint8_t pointer, uint8_t increment, uint8_t buffer_size);
+uint8_t decrement_pointer(uint8_t pointer, uint8_t decrement, uint8_t buffer_size);
 void cts_start(void);
 void cts_stop(void);
 void check_cts_stop(void);
@@ -1489,10 +1489,10 @@ static void memcpy_local(void *dst, const void *src, uint8_t len)
 }
 
 // Copy data from a circular buffer
-void circular_copy(uint8_t *dest, uint8_t *src, uint32_t src_size, uint32_t start_pos, uint32_t length) {
+void circular_copy(uint8_t *dest, uint8_t *src, uint8_t src_size, uint8_t start_pos, uint8_t length) {
 
     // Calculate the remaining space from start_pos to end of buffer
-    uint32_t remaining_space = src_size - start_pos;
+    uint8_t remaining_space = src_size - start_pos;
 
     if (length <= remaining_space) {
         // If the length to copy doesn't exceed the remaining space, do a single memcpy
@@ -1505,13 +1505,13 @@ void circular_copy(uint8_t *dest, uint8_t *src, uint32_t src_size, uint32_t star
 }
 
 // Function to increment a pointer and wrap around the buffer
-uint32_t increment_pointer(uint32_t pointer, uint32_t increment, uint32_t buffer_size)
+uint8_t increment_pointer(uint8_t pointer, uint8_t increment, uint8_t buffer_size)
 {
     return (pointer + increment) % buffer_size;
 }
 
 // Function to decrement a pointer and wrap around the buffer
-uint32_t decrement_pointer(uint32_t pointer, uint32_t decrement, uint32_t buffer_size)
+uint8_t decrement_pointer(uint8_t pointer, uint8_t decrement, uint8_t buffer_size)
 {
     return (pointer + buffer_size - (decrement % buffer_size)) % buffer_size;
 }

--- a/hw/usb_interface/ch552_fw/src/main.c
+++ b/hw/usb_interface/ch552_fw/src/main.c
@@ -632,11 +632,11 @@ FLASH uint8_t LineCoding[7] = { 0x20, 0xA1, 0x07, 0x00, /* Data terminal rate, i
 
 /** Communication UART */
 XDATA uint8_t UartTxBuf[UART_TX_BUF_SIZE] = { 0 };  // Serial transmit buffer
-volatile IDATA uint8_t Ep2ByteLen;
-volatile IDATA uint8_t Ep3ByteLen;
-volatile IDATA uint8_t Ep4ByteLen;
+IDATA uint8_t Ep2ByteLen;
+IDATA uint8_t Ep3ByteLen;
+IDATA uint8_t Ep4ByteLen;
 
-XDATA uint8_t UartRxBuf[UART_RX_BUF_SIZE] = { 0 };  // Serial receive buffer
+volatile XDATA uint8_t UartRxBuf[UART_RX_BUF_SIZE] = { 0 };  // Serial receive buffer
 volatile IDATA uint8_t UartRxBufInputPointer = 0;   // Circular buffer write pointer, bus reset needs to be initialized to 0
 volatile IDATA uint8_t UartRxBufOutputPointer = 0;  // Take pointer out of circular buffer, bus reset needs to be initialized to 0
 volatile IDATA uint8_t UartRxBufByteCount = 0;      // Number of unprocessed bytes remaining in the buffer
@@ -687,6 +687,7 @@ IDATA uint8_t FrameStarted = 0;
 IDATA uint8_t FrameDiscard = 0;
 IDATA uint8_t DiscardDataAvailable = 0;
 
+static void memcpy_local(void *dst, const void *src, uint8_t len);
 uint32_t increment_pointer(uint32_t pointer, uint32_t increment, uint32_t buffer_size);
 uint32_t decrement_pointer(uint32_t pointer, uint32_t decrement, uint32_t buffer_size);
 void cts_start(void);

--- a/hw/usb_interface/ch552_fw/src/main.c
+++ b/hw/usb_interface/ch552_fw/src/main.c
@@ -1463,7 +1463,7 @@ void Uart1_ISR(void)IRQ_UART1
     }
 }
 
-uint8_t uart_byte_count()
+uint8_t inline uart_byte_count()
 {
     uint8_t in = UartRxBufInputPointer;
     uint8_t out = UartRxBufOutputPointer;
@@ -1481,7 +1481,7 @@ uint8_t uart_byte_count()
 // This implementation is reentrant, given that source and destination buffers
 // are not accessed concurrently. Use this instead of memcpy() if it could be
 // interrupted.
-static void memcpy_local(void *dst, const void *src, uint8_t len)
+static inline void memcpy_local(void *dst, const void *src, uint8_t len)
 {
     uint8_t *d = dst;
     const uint8_t *s = src;

--- a/hw/usb_interface/ch552_fw/src/main.c
+++ b/hw/usb_interface/ch552_fw/src/main.c
@@ -627,15 +627,9 @@ FLASH uint8_t LineCoding[7] = { 0x20, 0xA1, 0x07, 0x00, /* Data terminal rate, i
                                                   0x08, /* Data bits (5, 6, 7, 8 or 16) */
                                 };
 
-#define UART_TX_BUF_SIZE     64   // Serial transmit buffer
 #define UART_RX_BUF_SIZE     140  // Serial receive buffer
 
 /** Communication UART */
-XDATA uint8_t UartTxBuf[UART_TX_BUF_SIZE] = { 0 };  // Serial transmit buffer
-IDATA uint8_t Ep2ByteLen;
-IDATA uint8_t Ep3ByteLen;
-IDATA uint8_t Ep4ByteLen;
-
 volatile XDATA uint8_t UartRxBuf[UART_RX_BUF_SIZE] = { 0 };  // Serial receive buffer
 volatile IDATA uint8_t UartRxBufInputPointer = 0;   // Circular buffer write pointer, bus reset needs to be initialized to 0
 volatile IDATA uint8_t UartRxBufOutputPointer = 0;  // Take pointer out of circular buffer, bus reset needs to be initialized to 0
@@ -1590,41 +1584,36 @@ void main()
 
             // Check if Endpoint 2 (CDC) has received data
             if (UsbEp2ByteCount) {
-                Ep2ByteLen = UsbEp2ByteCount; // UsbEp2ByteCount can be maximum 64 bytes
-                memcpy_local(UartTxBuf, Ep2Buffer, Ep2ByteLen);
 
-                UsbEp2ByteCount = 0;
                 CH554UART1SendByte(IO_CDC);  // Send CDC mode header
-                CH554UART1SendByte(Ep2ByteLen);  // Send length
-                CH554UART1SendBuffer(UartTxBuf, Ep2ByteLen);
+                CH554UART1SendByte(UsbEp2ByteCount);  // Send length
+                CH554UART1SendBuffer(Ep2Buffer, UsbEp2ByteCount);
+                UsbEp2ByteCount = 0;
                 UEP2_CTRL = (UEP2_CTRL & ~MASK_UEP_R_RES) | UEP_R_RES_ACK; // Enable Endpoint 2 to ACK again
             }
 
             // Check if Endpoint 3 (FIDO or CCID) has received data
             if (UsbEp3ByteCount) {
-                Ep3ByteLen = UsbEp3ByteCount; // UsbEp3ByteCount can be maximum 64 bytes
-                memcpy_local(UartTxBuf, Ep3Buffer, Ep3ByteLen);
 
-                UsbEp3ByteCount = 0;
                 if (ActiveEndpoints & IO_FIDO) {
                     CH554UART1SendByte(IO_FIDO); // Send FIDO mode header
                 } else if (ActiveEndpoints & IO_CCID) {
                     CH554UART1SendByte(IO_CCID); // Send CCID mode header
                 }
-                CH554UART1SendByte(Ep3ByteLen); // Send length (always 64 bytes for FIDO, variable for CCID)
-                CH554UART1SendBuffer(UartTxBuf, Ep3ByteLen);
+
+                CH554UART1SendByte(UsbEp3ByteCount); // Send length (always 64 bytes for FIDO, variable for CCID)
+                CH554UART1SendBuffer(Ep3Buffer, UsbEp3ByteCount);
+                UsbEp3ByteCount = 0;
                 UEP3_CTRL = (UEP3_CTRL & ~MASK_UEP_R_RES) | UEP_R_RES_ACK; // Enable Endpoint 3 to ACK again
             }
 
             // Check if Endpoint 4 (DEBUG) has received data
             if (UsbEp4ByteCount) {
-                Ep4ByteLen = UsbEp4ByteCount; // UsbEp4ByteCount can be maximum 64 bytes
-                memcpy_local(UartTxBuf, Ep0Buffer+64, Ep4ByteLen); // Endpoint 4 receive is at address UEP0_DMA+64
 
-                UsbEp4ByteCount = 0;
                 CH554UART1SendByte(IO_DEBUG); // Send DEBUG mode header
-                CH554UART1SendByte(Ep4ByteLen); // Send length (always 64 bytes)
-                CH554UART1SendBuffer(UartTxBuf, Ep4ByteLen);
+                CH554UART1SendByte(UsbEp4ByteCount); // Send length (always 64 bytes)
+                CH554UART1SendBuffer(Ep0Buffer+64, UsbEp4ByteCount); // Endpoint 4 receive is at address UEP0_DMA+64
+                UsbEp4ByteCount = 0;
                 UEP4_CTRL = (UEP4_CTRL & ~MASK_UEP_R_RES) | UEP_R_RES_ACK; // Enable Endpoint 4 to ACK again
             }
 

--- a/hw/usb_interface/ch552_fw/src/main.c
+++ b/hw/usb_interface/ch552_fw/src/main.c
@@ -1489,10 +1489,10 @@ static void memcpy_local(void *dst, const void *src, uint8_t len)
 }
 
 // Copy data from a circular buffer
-void inline circular_copy(uint8_t *dest, uint8_t *src, uint16_t src_size, uint8_t start_pos, uint8_t length) {
+void inline circular_copy(uint8_t *dest, uint8_t *src, uint8_t start_pos, uint8_t length) {
 
     // Calculate the remaining space from start_pos to end of buffer
-    uint8_t remaining_space = src_size - start_pos;
+    uint8_t remaining_space = 256 - start_pos;
 
     if (length <= remaining_space) {
         // If the length to copy doesn't exceed the remaining space, do a single memcpy
@@ -1657,7 +1657,6 @@ void main()
                         (UartRxBufByteCount >= MAX_FRAME_SIZE)) {
                         circular_copy(FrameBuf,
                                       UartRxBuf,
-                                      UART_RX_BUF_SIZE,
                                       UartRxBufOutputPointer,
                                       MAX_FRAME_SIZE);
                         FrameBufLength = MAX_FRAME_SIZE;
@@ -1673,7 +1672,6 @@ void main()
                              (UartRxBufByteCount >= FrameRemainingBytes)) {
                         circular_copy(FrameBuf,
                                       UartRxBuf,
-                                      UART_RX_BUF_SIZE,
                                       UartRxBufOutputPointer,
                                       FrameRemainingBytes);
                         FrameBufLength = FrameRemainingBytes;
@@ -1695,7 +1693,6 @@ void main()
                         (UartRxBufByteCount >= MAX_FRAME_SIZE)) {
                         circular_copy(FrameBuf,
                                       UartRxBuf,
-                                      UART_RX_BUF_SIZE,
                                       UartRxBufOutputPointer,
                                       MAX_FRAME_SIZE);
                         FrameBufLength = MAX_FRAME_SIZE;
@@ -1717,7 +1714,6 @@ void main()
                         (UartRxBufByteCount >= MAX_FRAME_SIZE)) {
                         circular_copy(FrameBuf,
                                       UartRxBuf,
-                                      UART_RX_BUF_SIZE,
                                       UartRxBufOutputPointer,
                                       MAX_FRAME_SIZE);
                         FrameBufLength = MAX_FRAME_SIZE;
@@ -1733,7 +1729,6 @@ void main()
                              (UartRxBufByteCount >= FrameRemainingBytes)) {
                         circular_copy(FrameBuf,
                                       UartRxBuf,
-                                      UART_RX_BUF_SIZE,
                                       UartRxBufOutputPointer,
                                       FrameRemainingBytes);
                         FrameBufLength = FrameRemainingBytes;
@@ -1755,7 +1750,6 @@ void main()
                         (UartRxBufByteCount >= MAX_FRAME_SIZE)) {
                         circular_copy(FrameBuf,
                                       UartRxBuf,
-                                      UART_RX_BUF_SIZE,
                                       UartRxBufOutputPointer,
                                       MAX_FRAME_SIZE);
                         FrameBufLength = MAX_FRAME_SIZE;
@@ -1771,7 +1765,6 @@ void main()
                              (UartRxBufByteCount >= FrameRemainingBytes)) {
                         circular_copy(FrameBuf,
                                       UartRxBuf,
-                                      UART_RX_BUF_SIZE,
                                       UartRxBufOutputPointer,
                                       FrameRemainingBytes);
                         FrameBufLength = FrameRemainingBytes;
@@ -1793,7 +1786,6 @@ void main()
                         (UartRxBufByteCount >= MAX_FRAME_SIZE)) {
                         circular_copy(FrameBuf,
                                       UartRxBuf,
-                                      UART_RX_BUF_SIZE,
                                       UartRxBufOutputPointer,
                                       MAX_FRAME_SIZE);
                         FrameBufLength = MAX_FRAME_SIZE;
@@ -1809,7 +1801,6 @@ void main()
                              (UartRxBufByteCount >= FrameRemainingBytes)) {
                         circular_copy(FrameBuf,
                                       UartRxBuf,
-                                      UART_RX_BUF_SIZE,
                                       UartRxBufOutputPointer,
                                       FrameRemainingBytes);
                         FrameBufLength = FrameRemainingBytes;

--- a/hw/usb_interface/ch552_fw/src/main.c
+++ b/hw/usb_interface/ch552_fw/src/main.c
@@ -30,9 +30,9 @@ XDATA AT00C0 uint8_t Ep1Buffer[DEFAULT_EP1_SIZE]  = { 0 }; // Endpoint 1, CDC Ct
 XDATA AT00C8 uint8_t Ep2Buffer[2*MAX_PACKET_SIZE] = { 0 }; // Endpoint 2, CDC Data endpoint, buffer OUT[64]+IN[64], must be an even address
 XDATA AT0148 uint8_t Ep3Buffer[2*MAX_PACKET_SIZE] = { 0 }; // Endpoint 3, FIDO endpoint, buffer OUT[64]+IN[64], must be an even address
 
-IDATA uint16_t SetupLen = 0;
-IDATA uint8_t SetupReq = 0;
-IDATA uint8_t UsbConfig = 0;
+uint16_t SetupLen = 0;
+uint8_t SetupReq = 0;
+uint8_t UsbConfig = 0;
 const uint8_t *pDescr = NULL;         // USB configuration flag
 
 #define UsbSetupBuf                   ((PUSB_SETUP_REQ)Ep0Buffer)
@@ -106,9 +106,9 @@ const uint8_t *pDescr = NULL;         // USB configuration flag
 #define BYTE2(x)   ((uint8_t)(((x) >> 16) & 0x000000FFU))  // Third byte
 #define BYTE3(x)   ((uint8_t)(((x) >> 24) & 0x000000FFU))  // Most significant byte
 
-IDATA uint8_t FidoInterfaceNum = 0;
-IDATA uint8_t CcidInterfaceNum = 0;
-IDATA uint8_t DebugInterfaceNum = 0;
+uint8_t FidoInterfaceNum = 0;
+uint8_t CcidInterfaceNum = 0;
+uint8_t DebugInterfaceNum = 0;
 
 XDATA uint8_t ActiveCfgDesc[MAX_CFG_DESC_SIZE];
 XDATA uint8_t ActiveCfgDescSize = 0;
@@ -631,9 +631,9 @@ FLASH uint8_t LineCoding[7] = { 0x20, 0xA1, 0x07, 0x00, /* Data terminal rate, i
 
 /** Communication UART */
 volatile XDATA uint8_t UartRxBuf[UART_RX_BUF_SIZE] = { 0 };  // Serial receive buffer
-volatile IDATA uint8_t UartRxBufInputPointer = 0;   // Circular buffer write pointer, bus reset needs to be initialized to 0
-volatile IDATA uint8_t UartRxBufOutputPointer = 0;  // Take pointer out of circular buffer, bus reset needs to be initialized to 0
-volatile IDATA uint8_t UartRxBufByteCount = 0;      // Number of unprocessed bytes remaining in the buffer
+volatile uint8_t UartRxBufInputPointer = 0;   // Circular buffer write pointer, bus reset needs to be initialized to 0
+volatile uint8_t UartRxBufOutputPointer = 0;  // Take pointer out of circular buffer, bus reset needs to be initialized to 0
+volatile uint8_t UartRxBufByteCount = 0;      // Number of unprocessed bytes remaining in the buffer
 
 /** Debug UART */
 #ifdef DEBUG_PRINT_HW
@@ -645,41 +645,41 @@ volatile IDATA uint8_t DebugUartRxBufByteCount = 0;
 #endif
 
 /** Endpoint handling */
-volatile IDATA uint8_t UsbEp2ByteCount = 0;     // Represents the data received by USB endpoint 2 (CDC)
-volatile IDATA uint8_t UsbEp3ByteCount = 0;     // Represents the data received by USB endpoint 3 (FIDO or CCID)
-volatile IDATA uint8_t UsbEp4ByteCount = 0;     // Represents the data received by USB endpoint 4 (DEBUG)
+volatile uint8_t UsbEp2ByteCount = 0;     // Represents the data received by USB endpoint 2 (CDC)
+volatile uint8_t UsbEp3ByteCount = 0;     // Represents the data received by USB endpoint 3 (FIDO or CCID)
+volatile uint8_t UsbEp4ByteCount = 0;     // Represents the data received by USB endpoint 4 (DEBUG)
 
-volatile IDATA uint8_t Endpoint2UploadBusy = 0; // Whether the upload endpoint 2 (CDC) is busy
-volatile IDATA uint8_t Endpoint3UploadBusy = 0; // Whether the upload endpoint 3 (FIDO or CCID) is busy
-volatile IDATA uint8_t Endpoint4UploadBusy = 0; // Whether the upload endpoint 4 (DEBUG) is busy
+volatile uint8_t Endpoint2UploadBusy = 0; // Whether the upload endpoint 2 (CDC) is busy
+volatile uint8_t Endpoint3UploadBusy = 0; // Whether the upload endpoint 3 (FIDO or CCID) is busy
+volatile uint8_t Endpoint4UploadBusy = 0; // Whether the upload endpoint 4 (DEBUG) is busy
 
 /** CH552 variables */
-IDATA uint8_t CH552DataAvailable = 0;
+uint8_t CH552DataAvailable = 0;
 
 /** DEBUG variables */
-IDATA uint8_t DebugDataAvailable = 0;
+uint8_t DebugDataAvailable = 0;
 
 /** CDC variables */
-IDATA uint8_t CdcDataAvailable = 0;
-IDATA uint8_t CdcSendZeroLenPacket = 0;
+uint8_t CdcDataAvailable = 0;
+uint8_t CdcSendZeroLenPacket = 0;
 
 /** FIDO variables */
-IDATA uint8_t FidoDataAvailable = 0;
+uint8_t FidoDataAvailable = 0;
 
 /** CCID variables */
-IDATA uint8_t CcidDataAvailable = 0;
+uint8_t CcidDataAvailable = 0;
 
 /** Frame data */
 #define MAX_FRAME_SIZE    64
 XDATA uint8_t FrameBuf[MAX_FRAME_SIZE] = { 0 };
-IDATA uint8_t FrameBufLength = 0;
+uint8_t FrameBufLength = 0;
 
-IDATA uint8_t FrameMode   = 0;
-IDATA uint8_t FrameLength = 0;
-IDATA uint8_t FrameRemainingBytes = 0;
-IDATA uint8_t FrameStarted = 0;
-IDATA uint8_t FrameDiscard = 0;
-IDATA uint8_t DiscardDataAvailable = 0;
+uint8_t FrameMode   = 0;
+uint8_t FrameLength = 0;
+uint8_t FrameRemainingBytes = 0;
+uint8_t FrameStarted = 0;
+uint8_t FrameDiscard = 0;
+uint8_t DiscardDataAvailable = 0;
 
 static void memcpy_local(void *dst, const void *src, uint8_t len);
 uint8_t increment_pointer(uint8_t pointer, uint8_t increment, uint8_t buffer_size);


### PR DESCRIPTION
## Description

These are low hanging fruits to optimize some speed and application size.
This is based on commit 1ed6ab6 (ch552: use memcpy_local) but should be disregarded in this PR.

Commit 1: Fix some volatile attributes. Just a small patch.

Commit 2: Remove UartTxBuf and the associated memcpy. This has proven to be safe during our investigation, and should speed up the main loop. It also saves us precious space, around 172 bytes.

Commit 3: Remove all use of uint32_t. This makes quite a major difference in application size, and hence also probably in speed. This simply removes our use of uint32_t to uint8_t, and since our largest buffer is 140 bytes this is still plenty. Ch552 is an 8-bit mcu, so uint32_t becomes expensive. This lowers the binary with approx 925 bytes, i.e. ~10% of the entire binary.

These fixes combined, but mostly the last, would increase the throughput of the CH552 and move the limit of how much data it can handle.

## Type of change
- [x] Bugfix (non breaking change which resolve an issue)


## Submission checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my changes
- [x] I have tested and verified my changes on target
- [ ] My changes are well written and CI is passing
- [ ] I have squashed my work to relevant commits and rebased on main for linear history
- [ ] I have added a "Co-authored-by: x" if several people contributed, either pair programming or by squashing commits from different authors.
- [ ] I have updated the documentation where relevant (readme, dev.tillitis.se etc.)
- [ ] QEMU is updated to reflect changes
