### PR TITLE
Fix size check in preload_load.

### DIFF
--- a/hw/application_fpga/fw/tk1/preload_app.c
+++ b/hw/application_fpga/fw/tk1/preload_app.c
@@ -31,8 +31,8 @@ int preload_load(struct partition_table *part_table, uint8_t from_slot)
 	}
 
 	// Check for a valid app in flash
-	if (part_table->pre_app_data[from_slot].size == 0 &&
-	    part_table->pre_app_data[from_slot].size <= TK1_APP_MAX_SIZE) {
+	if (part_table->pre_app_data[from_slot].size == 0 ||
+	    part_table->pre_app_data[from_slot].size > TK1_APP_MAX_SIZE) {
 		return -1;
 	}
 	uint8_t *loadaddr = (uint8_t *)TK1_RAM_BASE;


### PR DESCRIPTION
## Description

In `preload_load`, the expression guarding against apps of the wrong size is evaluating `size` against `0 AND <= TK1_APP_MAX_SIZE`, since `0` always satisfies `<= TK1_APP_MAX_SIZE`, the size check effectively only rejects zero-length apps.

This patch changes this to check for `0 OR > TK1_APP_MAX_SIZE`, so that an app larger than `TK1_APP_MAX_SIZE` is not able to write outside of the designated memory region.

Currently, this seems to only be called from `load_flash_app` where `size > TK1_APP_MAX_SIZE` _is_ checked, albeit after the call to `preload_load`.

## Type of change

Please tick any that are relevant to this PR and remove any that aren't.

- [*] Bugfix (non breaking change which resolve an issue)
- [ ] Feature (non breaking change which adds functionality)
- [ ] Breaking Change (a change which would cause existing functionality to not work as expected)
- [ ] Documentation (a change to documentation)

## Submission checklist

- [*] My code follows the style guidelines of this project
- [*] I have performed a self-review of my changes
- [ ] I have tested and verified my changes on target
- [ ] My changes are well written and CI is passing
- [*] I have squashed my work to relevant commits and rebased on main for linear history
- [ ] I have added a "Co-authored-by: x" if several people contributed, either pair programming or by squashing commits from different authors.
- [ ] I have updated the documentation where relevant (readme, dev.tillitis.se etc.)
- [ ] QEMU is updated to reflect changes
