### PR TITLE
ch552: allow printing the injected uuid

### DIFF
--- a/hw/usb_interface/ch552_fw/inject_serial_number.py
+++ b/hw/usb_interface/ch552_fw/inject_serial_number.py
@@ -9,12 +9,14 @@ import encode_usb_strings
 
 
 magic = encode_usb_strings.string_to_descriptor("68de5d27-e223-4874-bc76-a54d6e84068f")
-replacement = encode_usb_strings.string_to_descriptor(str(uuid.uuid4()))
+random_uuid = str(uuid.uuid4())
+replacement = encode_usb_strings.string_to_descriptor(random_uuid)
 
 
 parser = argparse.ArgumentParser(description='CH552 USB serial number injector. Replaces the default UUID with a randomly generated UUID4')
 parser.add_argument('-i', required=True, help='input file')
 parser.add_argument('-o', required=True, help='output file')
+parser.add_argument('-v', required=False, action="store_true", help='verbose, print new uuid')
 args = parser.parse_args()
 
 f = bytearray(open(args.i, 'rb').read())
@@ -30,3 +32,5 @@ f[pos:(pos+len(magic))] = replacement
 with open(args.o, 'wb') as of:
     of.write(f)
     
+if args.v:
+    print(f"{random_uuid}")


### PR DESCRIPTION
## Description

If one wants to test that the USB firmware flashed is the one that we added a new serial number to, knowing what serial number was injected is required. 

## Type of change
- [X] Feature (non breaking change which adds functionality)

## Submission checklist

- [ ] My code follows the style guidelines of this project
- [X] I have performed a self-review of my changes
- [X] I have tested and verified my changes on target
- [ ] My changes are well written and CI is passing
- [X] I have squashed my work to relevant commits and rebased on main for linear history
- [X] I have added a "Co-authored-by: x" if several people contributed, either pair programming or by squashing commits from different authors.
- [ ] I have updated the documentation where relevant (readme, dev.tillitis.se etc.)
- [ ] QEMU is updated to reflect changes
