### PR TITLE
CH552: Handle USB descriptor requests, remove sleep in SET_FEATURE request

### DIFF
--- a/hw/usb_interface/ch552_fw/src/main.c
+++ b/hw/usb_interface/ch552_fw/src/main.c
@@ -1134,17 +1134,10 @@ void UsbEp0SetupHandler(void)
                 if (( UsbSetupBuf->bmRequestType & USB_REQ_RECIP_MASK) == USB_REQ_RECIP_DEVICE) { // Set up the device
                     if ((((uint16_t) UsbSetupBuf->wValueH << 8) | UsbSetupBuf->wValueL) == 0x01) {
                         if (CfgDesc[7] & 0x20) {
-                            printStrSetup("Suspend\n");
-                            while (XBUS_AUX & bUART0_TX) {
-                                ; // Wait for sending to complete
-                            }
-                            SAFE_MOD = 0x55;
-                            SAFE_MOD = 0xAA;
-                            WAKE_CTRL = bWAK_BY_USB | bWAK_RXD0_LO | bWAK_RXD1_LO; // USB or RXD0/1 can be woken up when there is a signal
-                            PCON |= PD; // Sleep
-                            SAFE_MOD = 0x55;
-                            SAFE_MOD = 0xAA;
-                            WAKE_CTRL = 0x00;
+                            printStrSetup("Enable remote wake up\n");
+
+                                // Not implemented
+
                         } else {
                             len = 0xFF; // Operation failed
                         }
@@ -1177,6 +1170,7 @@ void UsbEp0SetupHandler(void)
                             break;
                         case 0x01:
                             UEP1_CTRL = (UEP1_CTRL & ~bUEP_R_TOG) | UEP_R_RES_STALL; // Set endpoint 1 OUT (RX) Stall (error)
+                            break;
                         default:
                             len = 0xFF; // Operation failed
                             break;

--- a/hw/usb_interface/ch552_fw/src/main.c
+++ b/hw/usb_interface/ch552_fw/src/main.c
@@ -930,10 +930,6 @@ void UsbEp0SetupHandler(void)
                     pDescr += len;
                     break;
 
-                case USB_DESC_TYPE_DEVICE_QUALIFIER:
-                    printStrSetup("DEVICE_QUALIFIER\n");
-                    break;
-
                 case USB_DESC_TYPE_CONFIGURATION:
                     printStrSetup("CONFIGURATION\n");
                     pDescr = ActiveCfgDesc; // Send the configuration descriptor to the buffer to be sent
@@ -1048,13 +1044,10 @@ void UsbEp0SetupHandler(void)
                     pDescr += len;
                     break;
 
-                case USB_DESC_TYPE_DEBUG:
-                    printStrSetup("DEBUG\n");
-                    break;
-
                 default:
                     printStrSetup("Unknown descriptor!\n");
                     len = 0xFF; // Unknown descriptor
+                    SetupLen = 0;
                     break;
                 } // END switch (UsbSetupBuf->wValueH)
                 break;
@@ -1079,6 +1072,10 @@ void UsbEp0SetupHandler(void)
 
             case USB_GET_INTERFACE:
                 printStrSetup("GET_INTERFACE\n");
+                Ep0Buffer[0] = 0x00;
+                if (SetupLen >= 1) {
+                    len = 1;
+                }
                 break;
 
             case USB_CLEAR_FEATURE:


### PR DESCRIPTION
## Description
Remove suspend code in the interrupt handler for SET_FEATURE, which removes an orphaned IN packet on the USB bus occurring at each startup. 

Explicitly handle all descriptor requests, and remove special handling of unused ones - so they instead are caught by the default path. Lowers the probability that pDescr and SetupLen goes out of sync.

Fixes #411 

## Type of change
- [x] Bugfix (non breaking change which resolve an issue)


## Submission checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my changes
- [x] I have tested and verified my changes on target
- [x] My changes are well written and CI is passing
- [x] I have squashed my work to relevant commits and rebased on main for linear history
- [x] I have added a "Co-authored-by: x" if several people contributed, either pair programming or by squashing commits from different authors.
- [ ] ~~I have updated the documentation where relevant (readme, dev.tillitis.se etc.)~~
- [ ] ~~QEMU is updated to reflect changes~~
