### PR TITLE
build: require and forward PACKAGE for flash targets

### DIFF
--- a/contrib/Makefile
+++ b/contrib/Makefile
@@ -91,11 +91,12 @@ run-make-clean_fw:
 	 $(IMAGE) make clean_fw application_fpga.bin PACKAGE=$(PACKAGE)
 
 flash:
+	$(CHECK_PACKAGE)
 	podman run --rm \
 	$(tp) \
 	--mount type=bind,source="`pwd`/../hw/application_fpga",target=/build \
 	-w /build \
-	-it $(IMAGE) make prog_flash
+	-it $(IMAGE) make prog_flash PACKAGE=$(PACKAGE)
 
 
 pull:

--- a/hw/application_fpga/Makefile
+++ b/hw/application_fpga/Makefile
@@ -42,6 +42,9 @@ PACKAGE_REQUIRED_TARGETS := \
 	application_fpga_testfw.bin \
 	check-binary-hashes \
 	lint \
+	prog_flash \
+	prog_flash_bs \
+	prog_flash_testfw \
 	synth.json \
 	tb_application_fpga \
 	timing \


### PR DESCRIPTION
## Description
Add prog_flash, prog_flash_bs, and prog_flash_testfw to PACKAGE_REQUIRED_TARGETS. Update the contrib flash target to run CHECK_PACKAGE and pass PACKAGE to the containerized make command.

## Type of change
- [x] Bugfix (non breaking change which resolve an issue)

## Submission checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my changes
- [ ] ~~I have tested and verified my changes on target~~
- [x] My changes are well written and CI is passing
- [x] I have squashed my work to relevant commits and rebased on main for linear history
- [x] I have added a "Co-authored-by: x" if several people contributed, either pair programming or by squashing commits from different authors.
- [ ] ~~I have updated the documentation where relevant (readme, dev.tillitis.se etc.)~~
- [ ] ~~QEMU is updated to reflect changes~~
